### PR TITLE
Reset selected trip state on modal close

### DIFF
--- a/src/components/pages/business-trip-list/hook.ts
+++ b/src/components/pages/business-trip-list/hook.ts
@@ -75,6 +75,8 @@ export function useBusinessTrips() {
 
   const closeAllModals = React.useCallback(() => {
     setModalState({ detail: false, approve: false, reject: false });
+    setSelectedId(null);
+    setSelectedTrip(undefined);
   }, []);
 
   const handleMutationError = React.useCallback(
@@ -134,9 +136,6 @@ export function useBusinessTrips() {
 
   const closeModal = React.useCallback((modal: BusinessTripModalKey) => {
     setModalState((prev) => ({ ...prev, [modal]: false }));
-    if (modal === "detail") {
-      setSelectedId(null);
-    }
   }, []);
 
   const selectTrip = React.useCallback((trip: IBusinessTripResponse) => {

--- a/src/components/pages/ess-business-trip/hook.ts
+++ b/src/components/pages/ess-business-trip/hook.ts
@@ -74,6 +74,8 @@ export function useEssBusinessTrips() {
 
   const closeAllModals = React.useCallback(() => {
     setModalState({ detail: false, add: false, cancel: false });
+    setSelectedId(null);
+    setSelectedTrip(undefined);
   }, []);
 
   const handleMutationError = React.useCallback(
@@ -121,9 +123,6 @@ export function useEssBusinessTrips() {
 
   const closeModal = React.useCallback((modal: EssBusinessTripModalKey) => {
     setModalState((prev) => ({ ...prev, [modal]: false }));
-    if (modal === "detail") {
-      setSelectedId(null);
-    }
   }, []);
 
   const selectTrip = React.useCallback((trip: IBusinessTripResponse) => {


### PR DESCRIPTION
Updated the closeAllModals and closeModal functions in business trip hooks to reset selected trip state by setting selectedId to null and selectedTrip to undefined. This change ensures that the state is properly cleared when modals are closed, improving the overall user experience.