### PR TITLE
feat: ESS Approvals inbox for leave and overtime

### DIFF
--- a/src/components/pages/ess-approvals/index.tsx
+++ b/src/components/pages/ess-approvals/index.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import * as React from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { Clock, CircleX, ClockCheck } from 'lucide-react';
+import {
+  essLeaveAction,
+  essOvertimeStatus,
+  getWaitingDashboardEmployee,
+} from '@/services/ess';
+import type { WaitingApprovalItem } from '@/services/ess/types';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { Separator } from '@/components/ui/separator';
+
+export default function EssApprovalsList() {
+  const t = useTranslations('ess');
+  const tCommon = useTranslations('common');
+  const tStatus = useTranslations('status');
+  const tSidebar = useTranslations('sidebar');
+  const queryClient = useQueryClient();
+
+  const [selected, setSelected] = React.useState<WaitingApprovalItem | null>(
+    null,
+  );
+  const [notes, setNotes] = React.useState('');
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['waitingStat'],
+    queryFn: () => getWaitingDashboardEmployee(),
+  });
+
+  const items = React.useMemo(() => {
+    const leaves = data?.data.leaves ?? [];
+    const overtimes = data?.data.overtimes ?? [];
+    return [...leaves, ...overtimes];
+  }, [data]);
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['waitingStat'] });
+  };
+
+  const leaveMutation = useMutation({
+    mutationFn: ({
+      id,
+      action,
+      notes,
+    }: {
+      id: number;
+      action: 'approve' | 'reject';
+      notes?: string;
+    }) => essLeaveAction(id, { action, notes }),
+    onSuccess: (_, vars) => {
+      toast.success(
+        vars.action === 'approve'
+          ? t('approvalsApproveSuccess')
+          : t('approvalsRejectSuccess'),
+      );
+      setSelected(null);
+      setNotes('');
+      invalidate();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || t('approvalsActionFailed'));
+    },
+  });
+
+  const overtimeMutation = useMutation({
+    mutationFn: ({ id, status }: { id: number; status: 2 | 3 }) =>
+      essOvertimeStatus(id, { status }),
+    onSuccess: (_, vars) => {
+      toast.success(
+        vars.status === 2
+          ? t('approvalsApproveSuccess')
+          : t('approvalsRejectSuccess'),
+      );
+      setSelected(null);
+      setNotes('');
+      invalidate();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || t('approvalsActionFailed'));
+    },
+  });
+
+  const isSubmitting = leaveMutation.isPending || overtimeMutation.isPending;
+
+  const handleApprove = () => {
+    if (!selected) return;
+    if (selected.type === 'leave') {
+      leaveMutation.mutate({
+        id: selected.id,
+        action: 'approve',
+        notes: notes.trim() || undefined,
+      });
+    } else {
+      overtimeMutation.mutate({ id: selected.id, status: 2 });
+    }
+  };
+
+  const handleReject = () => {
+    if (!selected) return;
+    if (selected.type === 'leave') {
+      leaveMutation.mutate({
+        id: selected.id,
+        action: 'reject',
+        notes: notes.trim() || undefined,
+      });
+    } else {
+      overtimeMutation.mutate({ id: selected.id, status: 3 });
+    }
+  };
+
+  const typeLabel = (item: WaitingApprovalItem) =>
+    item.type === 'leave'
+      ? tSidebar('leaveRequest')
+      : tSidebar('overtimeRequest');
+
+  const subtitle = (item: WaitingApprovalItem) => {
+    if (item.type === 'leave') {
+      const parts = [
+        item.leave_type?.name,
+        item.start_date && item.end_date
+          ? `${item.start_date} – ${item.end_date}`
+          : null,
+      ].filter(Boolean);
+      return parts.join(' · ');
+    }
+    const parts = [
+      item.overtime_date,
+      item.start_time && item.end_time
+        ? `${item.start_time} – ${item.end_time}`
+        : null,
+    ].filter(Boolean);
+    return parts.join(' · ');
+  };
+
+  return (
+    <div className="font-sans min-h-screen flex flex-col space-y-6 px-6">
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold text-xl text-primary">{t('approvals')}</h2>
+        {data?.data.total ? (
+          <Badge variant="secondary">{data.data.total}</Badge>
+        ) : null}
+      </div>
+
+      {isLoading ? (
+        <div className="text-sm text-muted-foreground">{tCommon('loading')}</div>
+      ) : items.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{t('approvalsEmpty')}</p>
+      ) : (
+        <div className="space-y-3">
+          {items.map((item) => (
+            <button
+              key={`${item.type}-${item.id}`}
+              type="button"
+              className="w-full text-left border rounded-lg p-4 space-y-2 hover:bg-muted/40 transition-colors"
+              onClick={() => {
+                setSelected(item);
+                setNotes('');
+              }}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <p className="font-medium text-sm text-primary">
+                  {typeLabel(item)}
+                </p>
+                <Badge
+                  variant="secondary"
+                  className="flex items-center gap-1 bg-yellow-50 border-yellow-800 text-yellow-800"
+                >
+                  <Clock className="w-3 h-3" />{' '}
+                  {tStatus('waitingForApproval')}
+                </Badge>
+              </div>
+              <p className="font-semibold">{item.user.name}</p>
+              {subtitle(item) ? (
+                <p className="text-sm text-muted-foreground">{subtitle(item)}</p>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <AlertDialog
+        open={!!selected}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelected(null);
+            setNotes('');
+          }
+        }}
+      >
+        <AlertDialogContent className="max-w-md bg-white">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('approvalsDetail')}</AlertDialogTitle>
+          </AlertDialogHeader>
+          {selected ? (
+            <div className="space-y-3 text-sm">
+              <div>
+                <div className="text-muted-foreground">{t('approvalsType')}</div>
+                <div className="font-medium">{typeLabel(selected)}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">
+                  {t('approvalsEmployee')}
+                </div>
+                <div className="font-medium">{selected.user.name}</div>
+              </div>
+              {selected.type === 'leave' ? (
+                <>
+                  {selected.leave_type?.name ? (
+                    <div>
+                      <div className="text-muted-foreground">
+                        {t('approvalsLeaveType')}
+                      </div>
+                      <div className="font-medium">
+                        {selected.leave_type.name}
+                      </div>
+                    </div>
+                  ) : null}
+                  {selected.start_date && selected.end_date ? (
+                    <div>
+                      <div className="text-muted-foreground">
+                        {tCommon('duration')}
+                      </div>
+                      <div className="font-medium">
+                        {selected.start_date} – {selected.end_date}
+                      </div>
+                    </div>
+                  ) : null}
+                  {selected.reason ? (
+                    <div>
+                      <div className="text-muted-foreground">
+                        {t('approvalsReason')}
+                      </div>
+                      <div className="font-medium">{selected.reason}</div>
+                    </div>
+                  ) : null}
+                  <Separator />
+                  <div>
+                    <div className="text-muted-foreground mb-2">
+                      {t('approvalsNotesOptional')}
+                    </div>
+                    <Textarea
+                      value={notes}
+                      onChange={(e) => setNotes(e.target.value)}
+                      placeholder={t('approvalsNotesHint')}
+                      rows={3}
+                    />
+                  </div>
+                </>
+              ) : (
+                <>
+                  {selected.overtime_date ? (
+                    <div>
+                      <div className="text-muted-foreground">
+                        {t('approvalsOvertimeDate')}
+                      </div>
+                      <div className="font-medium">{selected.overtime_date}</div>
+                    </div>
+                  ) : null}
+                  {selected.start_time && selected.end_time ? (
+                    <div>
+                      <div className="text-muted-foreground">
+                        {t('approvalsTime')}
+                      </div>
+                      <div className="font-medium">
+                        {selected.start_time} – {selected.end_time}
+                      </div>
+                    </div>
+                  ) : null}
+                  {selected.notes ? (
+                    <div>
+                      <div className="text-muted-foreground">
+                        {tCommon('notes')}
+                      </div>
+                      <div className="font-medium">{selected.notes}</div>
+                    </div>
+                  ) : null}
+                </>
+              )}
+            </div>
+          ) : null}
+          <AlertDialogFooter className="gap-2 sm:gap-2">
+            <AlertDialogCancel disabled={isSubmitting}>
+              {tCommon('cancel')}
+            </AlertDialogCancel>
+            <Button
+              type="button"
+              variant="outline"
+              className="border-red-500 text-red-500"
+              disabled={isSubmitting}
+              onClick={handleReject}
+            >
+              <CircleX className="w-4 h-4" />
+              {tCommon('reject')}
+            </Button>
+            <AlertDialogAction
+              disabled={isSubmitting}
+              onClick={(e) => {
+                e.preventDefault();
+                handleApprove();
+              }}
+            >
+              <ClockCheck className="w-4 h-4" />
+              {t('approveRequest')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/pages/ess/page.tsx
+++ b/src/components/pages/ess/page.tsx
@@ -31,19 +31,26 @@ function WaitingApprovalCard({
   formatDate,
   notesLabel,
   waitingLabel,
+  onClick,
 }: {
   title: string;
   item: WaitingApprovalDataMeta;
   formatDate: (date: string) => string;
   notesLabel: string;
   waitingLabel: string;
+  onClick?: () => void;
 }) {
   return (
-    <div className="border rounded-lg p-4 space-y-2">
+    <button
+      type="button"
+      className="w-full text-left border rounded-lg p-4 space-y-2 hover:bg-muted/40 transition-colors"
+      onClick={onClick}
+    >
       <p className="font-medium text-sm">{title}</p>
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-2">
         <p className="font-semibold">
-          {item.created_at ? formatDate(item.created_at) : '-'}
+          {item.user?.name ??
+            (item.created_at ? formatDate(item.created_at) : '-')}
         </p>
         <Badge
           variant="secondary"
@@ -52,6 +59,11 @@ function WaitingApprovalCard({
           <Clock className="w-3 h-3" /> {waitingLabel}
         </Badge>
       </div>
+      {item.created_at ? (
+        <p className="text-xs text-muted-foreground">
+          {formatDate(item.created_at)}
+        </p>
+      ) : null}
       {item.comments ? (
         <>
           <Separator />
@@ -63,7 +75,7 @@ function WaitingApprovalCard({
           </div>
         </>
       ) : null}
-    </div>
+    </button>
   );
 }
 
@@ -350,6 +362,7 @@ export const EssPage = () => {
                       formatDate={formatDate}
                       notesLabel={tCommon('notes')}
                       waitingLabel={tStatus('waitingForApproval')}
+                      onClick={() => router.push('/ess/approvals')}
                     />
                   ))
                 ) : (

--- a/src/components/pages/ess/sections/overview/index.tsx
+++ b/src/components/pages/ess/sections/overview/index.tsx
@@ -8,6 +8,7 @@ import { SectionOvertime } from "./section-overtime";
 import { SectionOffboarding } from "./section-offboarding";
 import { SectionOkr } from "./section-okr";
 import { SectionBusinessTrip } from "./section-business-trip";
+import { SectionApprovals } from "./section-approvals";
 
 type EssOverviewProps = {
   overview?: string;
@@ -22,6 +23,8 @@ export default function EssOverview({ overview }: EssOverviewProps) {
         return <SectionOkr />;
       case "business-trip":
         return <SectionBusinessTrip />;
+      case "approvals":
+        return <SectionApprovals />;
       case "organization":
         return <SectionOrganization />;
       case "assessment":

--- a/src/components/pages/ess/sections/overview/section-approvals.tsx
+++ b/src/components/pages/ess/sections/overview/section-approvals.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import * as React from "react";
+import EssApprovalsList from "@/components/pages/ess-approvals";
+
+export const SectionApprovals = () => {
+  return (
+    <div className="font-sans min-h-screen flex flex-col py-6">
+      <EssApprovalsList />
+    </div>
+  );
+};

--- a/src/components/pages/ess/sections/quick-access.tsx
+++ b/src/components/pages/ess/sections/quick-access.tsx
@@ -2,6 +2,7 @@
 
 import {
   ClockPlusIcon,
+  ClipboardCheck,
   GitCompareArrowsIcon,
   Plane,
   Target,
@@ -10,11 +11,20 @@ import {
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getWaitingDashboardEmployee } from '@/services/ess';
 
 export const EssQuickActions = () => {
   const router = useRouter();
   const t = useTranslations('ess');
   const tSidebar = useTranslations('sidebar');
+
+  const { data: waitingStat } = useQuery({
+    queryKey: ['waitingStat'],
+    queryFn: () => getWaitingDashboardEmployee(),
+  });
+
+  const approvalsCount = waitingStat?.data.total ?? 0;
 
   const pannel = [
     {
@@ -38,6 +48,12 @@ export const EssQuickActions = () => {
       icon: <Plane className="text-white" />,
     },
     {
+      title: t('approvals'),
+      path: '/ess/approvals',
+      icon: <ClipboardCheck className="text-white" />,
+      badge: approvalsCount,
+    },
+    {
       title: tSidebar('selfAssessment'),
       path: '/ess/assessment',
       icon: <UserStarIcon className="text-white" />,
@@ -52,13 +68,18 @@ export const EssQuickActions = () => {
   return (
     <div className="font-sans flex flex-col space-y-6">
       <div className="font-bold text-xl text-primary">{t('quickActions')}</div>
-      <div className="grid grid-cols-1 md:grid-cols-6 gap-8">
+      <div className="grid grid-cols-1 md:grid-cols-4 lg:grid-cols-7 gap-8">
         {pannel.map((item, id) => (
           <div
-            className="h-30 w-full rounded-lg flex flex-col bg-primary/10 border border-primary items-center justify-center text-center cursor-pointer"
+            className="relative h-30 w-full rounded-lg flex flex-col bg-primary/10 border border-primary items-center justify-center text-center cursor-pointer"
             key={id}
             onClick={() => router.push(item.path)}
           >
+            {'badge' in item && item.badge && item.badge > 0 ? (
+              <span className="absolute top-2 right-2 min-w-5 h-5 px-1.5 rounded-full bg-red-600 text-white text-xs font-semibold flex items-center justify-center">
+                {item.badge > 99 ? '99+' : item.badge}
+              </span>
+            ) : null}
             <div className="h-10 w-10 rounded-full flex items-center justify-center bg-primary mb-3">
               {item.icon}
             </div>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1570,7 +1570,22 @@
     "organizationStructure": "Organization Structure",
     "onLeaveToday": "On Leave Today",
     "waitingForApproval": "Waiting For Approval",
-    "pageNotFound": "Page not found"
+    "pageNotFound": "Page not found",
+    "approvals": "Approvals",
+    "approvalsEmpty": "No pending approvals",
+    "approvalsDetail": "Approval Detail",
+    "approvalsType": "Type",
+    "approvalsEmployee": "Employee",
+    "approvalsLeaveType": "Leave Type",
+    "approvalsReason": "Reason",
+    "approvalsOvertimeDate": "Overtime Date",
+    "approvalsTime": "Time",
+    "approvalsNotesOptional": "Notes (optional)",
+    "approvalsNotesHint": "Add a note",
+    "approvalsApproveSuccess": "Request approved",
+    "approvalsRejectSuccess": "Request rejected",
+    "approvalsActionFailed": "Failed to update approval",
+    "approveRequest": "Approve Request"
   },
   "formatting": {
     "days": "{count} days",

--- a/src/messages/id.json
+++ b/src/messages/id.json
@@ -1570,7 +1570,22 @@
     "organizationStructure": "Struktur Organisasi",
     "onLeaveToday": "Sedang Cuti Hari Ini",
     "waitingForApproval": "Menunggu Persetujuan",
-    "pageNotFound": "Halaman tidak ditemukan"
+    "pageNotFound": "Halaman tidak ditemukan",
+    "approvals": "Persetujuan",
+    "approvalsEmpty": "Tidak ada persetujuan menunggu",
+    "approvalsDetail": "Detail Persetujuan",
+    "approvalsType": "Jenis",
+    "approvalsEmployee": "Karyawan",
+    "approvalsLeaveType": "Jenis Cuti",
+    "approvalsReason": "Alasan",
+    "approvalsOvertimeDate": "Tanggal Lembur",
+    "approvalsTime": "Waktu",
+    "approvalsNotesOptional": "Catatan (opsional)",
+    "approvalsNotesHint": "Tambahkan catatan",
+    "approvalsApproveSuccess": "Permintaan disetujui",
+    "approvalsRejectSuccess": "Permintaan ditolak",
+    "approvalsActionFailed": "Gagal memperbarui persetujuan",
+    "approveRequest": "Setujui Permintaan"
   },
   "formatting": {
     "days": "{count} hari",

--- a/src/services/ess/index.ts
+++ b/src/services/ess/index.ts
@@ -1,5 +1,10 @@
 import { apiEmployee } from "@/lib/api";
-import { DashboardAttendanceResponse, WaitingResponse } from "./types";
+import {
+  DashboardAttendanceResponse,
+  EssLeaveActionPayload,
+  EssOvertimeStatusPayload,
+  WaitingResponse,
+} from "./types";
 
 export const getAttendanceDashboardEmployee = async (
   filters: { start_date?: string; end_date?: string }
@@ -29,3 +34,25 @@ export const getWaitingDashboardEmployee = async (): Promise<WaitingResponse> =>
 
   return response.json()
 }
+
+export const essLeaveAction = async (
+  leaveId: number,
+  payload: EssLeaveActionPayload,
+) => {
+  const response = await apiEmployee.post(
+    `ess/leave/${leaveId}/action`,
+    { json: payload },
+  );
+  return response.json();
+};
+
+export const essOvertimeStatus = async (
+  overtimeId: number,
+  payload: EssOvertimeStatusPayload,
+) => {
+  const response = await apiEmployee.post(
+    `ess/overtime/${overtimeId}/status`,
+    { json: payload },
+  );
+  return response.json();
+};

--- a/src/services/ess/types.ts
+++ b/src/services/ess/types.ts
@@ -36,21 +36,49 @@ export interface WaitingResponse {
 }
 
 export interface WaitingApprovalData {
-  leaves: WaitingApprovalDataMeta[];
-  overtimes: WaitingApprovalDataMeta[];
-  offboardings: WaitingApprovalDataMeta[];
+  leaves: WaitingApprovalItem[];
+  overtimes: WaitingApprovalItem[];
+  offboardings: WaitingApprovalItem[];
   total: number;
 }
 
-export interface WaitingApprovalDataMeta {
-    approver_status: number;
+/** @deprecated Use WaitingApprovalItem */
+export type WaitingApprovalDataMeta = WaitingApprovalItem;
+
+export interface WaitingApprovalItem {
+  id: number;
+  type: 'leave' | 'overtime' | 'offboarding' | string;
+  user: {
     id: number;
-    comments: string;
-    created_at: string;
-    type: string;
-    user: {
-        name: string;
-        id: number;
-        email: string;
-    }
+    name: string;
+    email: string;
+  };
+  leave_type?: {
+    id: number;
+    name: string;
+  } | null;
+  start_date?: string;
+  end_date?: string;
+  reason?: string;
+  overtime_date?: string;
+  request_date?: string;
+  start_time?: string;
+  end_time?: string;
+  duration?: string | number;
+  notes?: string;
+  comments?: string;
+  status?: number;
+  status_label?: string;
+  approver_status?: number;
+  approver_notes?: string;
+  created_at?: string;
+}
+
+export interface EssLeaveActionPayload {
+  action: 'approve' | 'reject';
+  notes?: string;
+}
+
+export interface EssOvertimeStatusPayload {
+  status: 2 | 3;
 }


### PR DESCRIPTION
## Summary
- Add ESS Approvals Quick Action (after Business Trip) with pending badge.
- Add `/ess/approvals` list + detail approve/reject for leave and overtime.
- Wire home waiting cards to Approvals; call ESS action APIs (not HR `employee/*`).

## Test plan
- [ ] ESS home shows Approvals tile with badge matching waiting total
- [ ] Waiting cards navigate to `/ess/approvals`
- [ ] Supervisor can approve/reject leave and overtime from Approvals
- [ ] Requester sees empty Approvals / cannot act on own requests
- [ ] Depends on core-hrms `feat/approvals` ESS action endpoints
