### PR TITLE
fix: KPI/OKR optional targets and mobile password-reset bridge

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -16,3 +16,6 @@ NEXT_PUBLIC_BASE_URL_RECOGNITION=https://face-staging.okejobhub.fun/api/v1
 
 # Base URL API employee
 NEXT_PUBLIC_BASE_URL_EMPLOYEE=https://api-staging.okejobhub.fun/api
+
+# Optional: ESS custom-scheme base used by /app/reset-password bridge (default hrms-app://com.okjob.hrms)
+# NEXT_PUBLIC_MOBILE_DEEP_LINK_URL=hrms-app://com.okjob.hrms

--- a/src/app/app/reset-password/page.tsx
+++ b/src/app/app/reset-password/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useMemo } from 'react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+
+const DEFAULT_MOBILE_DEEP_LINK_BASE = 'hrms-app://com.okjob.hrms';
+
+function buildMobileDeepLink(token: string, email: string): string {
+  const base = (
+    process.env.NEXT_PUBLIC_MOBILE_DEEP_LINK_URL || DEFAULT_MOBILE_DEEP_LINK_BASE
+  ).replace(/\/$/, '');
+  const query = new URLSearchParams({ token, email }).toString();
+  return `${base}/reset-password?${query}`;
+}
+
+export default function MobileResetPasswordBridgePage() {
+  const searchParams = useSearchParams();
+  const t = useTranslations('auth');
+  const token = searchParams.get('token') ?? '';
+  const email = searchParams.get('email') ?? '';
+
+  const deepLink = useMemo(() => {
+    if (!token || !email) {
+      return null;
+    }
+    return buildMobileDeepLink(token, email);
+  }, [token, email]);
+
+  const webHref =
+    token && email
+      ? `/reset-password?token=${encodeURIComponent(token)}&email=${encodeURIComponent(email)}`
+      : '/auth/reset-password';
+
+  useEffect(() => {
+    if (!deepLink) {
+      return;
+    }
+    // Attempt to open ESS automatically when this HTTPS bridge is opened from email.
+    window.location.href = deepLink;
+  }, [deepLink]);
+
+  if (!token || !email) {
+    return (
+      <div className="max-w-md mx-auto min-h-screen flex flex-col justify-center px-6 text-center">
+        <h1 className="text-2xl font-bold mb-2">{t('resetPassword')}</h1>
+        <p className="text-muted-foreground mb-6">{t('resetLinkInvalid')}</p>
+        <Button asChild>
+          <Link href="/auth/reset-password">{t('requestNewResetLink')}</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-md mx-auto min-h-screen flex flex-col justify-center px-6 text-center">
+      <h1 className="text-2xl font-bold mb-2">{t('openEssAppTitle')}</h1>
+      <p className="text-muted-foreground mb-6">{t('openEssAppSubtitle')}</p>
+
+      <div className="flex flex-col gap-3">
+        <Button asChild className="w-full">
+          <a href={deepLink ?? '#'}>{t('openEssAppCta')}</a>
+        </Button>
+        <Button asChild variant="outline" className="w-full">
+          <Link href={webHref}>{t('continueResetOnWeb')}</Link>
+        </Button>
+      </div>
+
+      <p className="text-sm text-muted-foreground mt-6">
+        {t('openEssAppHint')}
+      </p>
+    </div>
+  );
+}

--- a/src/components/pages/auth-reset-password/index.tsx
+++ b/src/components/pages/auth-reset-password/index.tsx
@@ -20,7 +20,7 @@ export default function ResetPasswordPage() {
 
   const { mutate, isPending } = useMutation({
     mutationFn: async () => {
-      return postRequestReset({ email });
+      return postRequestReset({ email, client: 'web' });
     },
     onSuccess: () => {
       toast.success(tToast('resetMailSuccess'));

--- a/src/components/pages/ess/sections/overview/detail/section-assessment-detail.tsx
+++ b/src/components/pages/ess/sections/overview/detail/section-assessment-detail.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
-import { getFields } from "@/services/form";
+import { getFormById } from "@/services/form";
 import {
   getEmployeeSelfAssessmentDetail,
   getEmployeeSelfAssessments,
@@ -13,6 +13,7 @@ import { SurveyAssessmentForm } from "./survey-assessment-form";
 import { toast } from "sonner";
 import { IMutateEmployeeSelfAssessmentRequest } from "@/services/employees/self-assessment/types";
 import { ApiErrorResponse } from "@/lib/types";
+import { IFieldResponse } from "@/services/form/types";
 
 interface SectionAssessmentDetailProps {
   assessmentId: string | number;
@@ -29,10 +30,24 @@ export const SectionAssessmentDetail: React.FC<
 
   const { data: formDetail, isLoading: isLoadingForm } = useQuery({
     queryKey: ["form-detail", formId],
-    queryFn: () => getFields({ form_id: formId! }),
+    queryFn: () => getFormById(formId!),
     enabled: !!formId,
     staleTime: 0,
   });
+
+  const formFields = React.useMemo((): IFieldResponse[] => {
+    const groups = formDetail?.data?.groups;
+    if (!groups?.length) return [];
+
+    return groups.flatMap((group) =>
+      (group.fields ?? []).map((field) => ({
+        ...field,
+        field_group_id: Number(
+          (field as { field_group_id?: number }).field_group_id ?? group.id,
+        ),
+      })),
+    ) as IFieldResponse[];
+  }, [formDetail?.data?.groups]);
 
   const { data: assessmentDetail, isLoading: isLoadingAssessment } = useQuery({
     queryKey: ["assessment-detail", Number(assessmentId)],
@@ -120,9 +135,9 @@ export const SectionAssessmentDetail: React.FC<
       </div>
 
       <div className="bg-white rounded-lg shadow-sm border p-6 w-full">
-        {formDetail?.data ? (
+        {formFields.length > 0 ? (
           <SurveyAssessmentForm
-            fields={formDetail.data}
+            fields={formFields}
             onSubmit={isReadOnly ? undefined : submitAssessment}
             isSubmitting={isSubmitting}
             initialData={employeeSubmission}

--- a/src/components/pages/ess/sections/overview/detail/section-assessment-validate.tsx
+++ b/src/components/pages/ess/sections/overview/detail/section-assessment-validate.tsx
@@ -7,7 +7,7 @@ import { useTranslations } from "next-intl";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { getFields } from "@/services/form";
+import { getFormById } from "@/services/form";
 import {
   getEmployeeSelfAssessmentDetail,
   getEmployeeSelfAssessments,
@@ -20,6 +20,7 @@ import {
 } from "@/services/employees/self-assessment/types";
 import { ApiErrorResponse } from "@/lib/types";
 import { SurveyAssessmentForm } from "./survey-assessment-form";
+import { IFieldResponse } from "@/services/form/types";
 
 interface SectionAssessmentValidateProps {
   memberEsaId: string | number;
@@ -69,10 +70,24 @@ export const SectionAssessmentValidate: React.FC<
 
   const { data: formDetail, isLoading: isLoadingForm } = useQuery({
     queryKey: ["form-detail", resolvedFormId],
-    queryFn: () => getFields({ form_id: resolvedFormId! }),
+    queryFn: () => getFormById(resolvedFormId!),
     enabled: !!resolvedFormId,
     staleTime: 0,
   });
+
+  const formFields = React.useMemo((): IFieldResponse[] => {
+    const groups = formDetail?.data?.groups;
+    if (!groups?.length) return [];
+
+    return groups.flatMap((group) =>
+      (group.fields ?? []).map((field) => ({
+        ...field,
+        field_group_id: Number(
+          (field as { field_group_id?: number }).field_group_id ?? group.id,
+        ),
+      })),
+    ) as IFieldResponse[];
+  }, [formDetail?.data?.groups]);
 
   const { data: assessmentDetail, isLoading: isLoadingAssessment } = useQuery({
     queryKey: ["assessment-detail", Number(memberEsaId)],
@@ -164,7 +179,7 @@ export const SectionAssessmentValidate: React.FC<
         </div>
       </div>
 
-      {!formDetail?.data ? (
+      {!formFields.length ? (
         <div className="text-center text-gray-500 py-8">{t("noFormFields")}</div>
       ) : (
         <Tabs defaultValue="self" className="w-full">
@@ -177,7 +192,7 @@ export const SectionAssessmentValidate: React.FC<
           <TabsContent value="self" className="mt-4">
             <div className="bg-white rounded-lg shadow-sm border p-6 w-full">
               <SurveyAssessmentForm
-                fields={formDetail.data}
+                fields={formFields}
                 mode="readonly"
                 initialData={employeeSubmission}
               />
@@ -191,7 +206,7 @@ export const SectionAssessmentValidate: React.FC<
                 </p>
               )}
               <SurveyAssessmentForm
-                fields={formDetail.data}
+                fields={formFields}
                 mode={isValidated ? "readonly" : "validate"}
                 initialData={
                   validationSubmission ??

--- a/src/components/pages/ess/sections/overview/detail/survey-assessment-form.tsx
+++ b/src/components/pages/ess/sections/overview/detail/survey-assessment-form.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from "react";
-import { useForm, FormProvider, useFormContext } from "react-hook-form";
+import { useForm, FormProvider, useFormContext, useWatch } from "react-hook-form";
 import { useTranslations } from "next-intl";
 import { CheckboxForm } from "@/components/ui/checkbox-form";
 import { TextAreaForm } from "@/components/ui/textarea";
@@ -15,6 +15,8 @@ import {
   IMutateEmployeeSelfAssessmentRequest,
   IAssessmentSubmission,
 } from "@/services/employees/self-assessment/types";
+import { resolveAssessmentKeterangan } from "@/lib/assessment-field-keterangan";
+import { AssessmentFieldKeterangan } from "@/components/pages/shared/assessment-field-keterangan";
 
 export type SurveyAssessmentFormMode = "submit" | "validate" | "readonly";
 
@@ -45,7 +47,7 @@ const RadioCardField = ({
   return (
     <FormItem className="space-y-3">
       <RadioGroupPrimitive.Root
-        className="w-full grid grid-cols-5 gap-3"
+        className="w-full flex flex-wrap gap-3"
         value={field.value}
         onValueChange={disabled ? undefined : field.onChange}
         disabled={disabled}
@@ -56,7 +58,7 @@ const RadioCardField = ({
             value={option.value}
             disabled={disabled}
             className={cn(
-              "ring-[1px] ring-border rounded py-1 px-3 focus:outline-none text-text-disabled",
+              "min-w-11 ring-[1px] ring-border rounded py-1 px-3 focus:outline-none text-text-disabled",
               disabled ? "cursor-default opacity-90" : "cursor-pointer",
               "data-[state=checked]:ring-primary data-[state=checked]:bg-primary data-[state=checked]:text-white",
               !disabled && "hover:bg-gray-50 transition-colors",
@@ -81,6 +83,7 @@ const SurveyFormFieldRenderer = ({
   const { control } = useFormContext();
   const t = useTranslations("performance");
   const fieldName = field.id.toString();
+  const watchedValue = useWatch({ control, name: fieldName });
 
   const commonProps = {
     name: fieldName,
@@ -100,9 +103,7 @@ const SurveyFormFieldRenderer = ({
                 <span className="text-destructive">*</span>
               )}
             </div>
-            {field.description && (
-              <p className="text-sm text-gray-500">{field.description}</p>
-            )}
+            <AssessmentFieldKeterangan description={field.description} />
             <div className="flex flex-col gap-2">
               {field.options.map((option: string) => (
                 <CheckboxForm
@@ -124,31 +125,45 @@ const SurveyFormFieldRenderer = ({
           {...commonProps}
           placeholder={t("typeAnswerHere")}
           labelClassName="font-medium"
+          description={field.description || undefined}
         />
       );
 
     case "range": {
       const min = field.options?.min || 1;
       const max = field.options?.max || 5;
+      const keterangan = resolveAssessmentKeterangan(
+        field.description,
+        field.competency_levels,
+        watchedValue,
+      );
 
       return (
         <FormField
           control={control}
           name={fieldName}
           rules={{
-            required: field.is_required && !readOnly ? t("fieldRequired") : false,
+            required:
+              field.is_required && !readOnly ? t("fieldRequired") : false,
           }}
           render={({ field: formField }) => (
             <div className="space-y-2">
               <div className="font-medium text-sm">
                 {field.label}
+                {field.metadata?.score_weight != null && (
+                  <span className="text-text-secondary font-normal">
+                    {" "}
+                    ({field.metadata.score_weight}%)
+                  </span>
+                )}
                 {field.is_required && !readOnly && (
                   <span className="text-destructive">*</span>
                 )}
               </div>
-              {field.description && (
-                <p className="text-sm text-gray-500">{field.description}</p>
-              )}
+              <AssessmentFieldKeterangan
+                description={keterangan.description}
+                levelName={keterangan.levelName}
+              />
               <RadioCardField
                 field={formField}
                 min={min}
@@ -169,6 +184,7 @@ const SurveyFormFieldRenderer = ({
           placeholder={t("typeHere")}
           labelClassName="font-medium"
           disabled={readOnly}
+          description={field.description || undefined}
         />
       );
   }

--- a/src/components/pages/performance-kpi/sections/form-modal.tsx
+++ b/src/components/pages/performance-kpi/sections/form-modal.tsx
@@ -137,8 +137,14 @@ export default function FormModal({
       format: Number(formData.format),
       job_position_ids: formData.job_position_ids,
       job_level_ids: formData.job_level_ids,
-      target: formData.target ? Number(formData.target) : 0,
-      direction: formData.direction ? Number(formData.direction) : 0,
+      target: (() => {
+        const value = Number(formData.target);
+        return Number.isFinite(value) ? value : 0;
+      })(),
+      direction: (() => {
+        const value = Number(formData.direction);
+        return Number.isFinite(value) ? value : 0;
+      })(),
       aggregation: Number(formData.aggregation),
     };
     onSave(data);

--- a/src/components/pages/performance-okr-details/sections/form-kpi.tsx
+++ b/src/components/pages/performance-okr-details/sections/form-kpi.tsx
@@ -80,6 +80,17 @@ export const FormKpi = ({
     const selectedKpi = kpiOptions.find(
       (option) => option.value === formData.name?.toString(),
     );
+    const toNumberOrDefault = (
+      value: unknown,
+      fallback: number,
+    ): number => {
+      if (value === null || value === undefined || value === "") {
+        return fallback;
+      }
+      const n = Number(value);
+      return Number.isFinite(n) ? n : fallback;
+    };
+
     const data: IOKRKeyResultRequest = {
       objective_id: formData.objective_id,
       title: selectedKpi ? selectedKpi.label : formData.name,
@@ -88,8 +99,8 @@ export const FormKpi = ({
       format: Number(formData.format),
       job_position_id: formData.job_position_id,
       job_level_id: formData.job_level_id,
-      target_value: Number(formData.target),
-      direction: Number(formData.direction),
+      target_value: toNumberOrDefault(formData.target, 0),
+      direction: toNumberOrDefault(formData.direction, 0),
       aggregation: Number(formData.aggregation),
     };
     onSave(data);

--- a/src/components/pages/performance-self-assessment-details/employee-details/sections/form-field-renderer.tsx
+++ b/src/components/pages/performance-self-assessment-details/employee-details/sections/form-field-renderer.tsx
@@ -6,6 +6,8 @@ import RadioCard from "@/components/ui/radio-card";
 import { FormField } from "@/components/pages/settings-form-template-details/type";
 import { IAssessmentField } from "@/services/employees/self-assessment/types";
 import { useFormContext } from "react-hook-form";
+import { resolveAssessmentKeterangan } from "@/lib/assessment-field-keterangan";
+import { AssessmentFieldKeterangan } from "@/components/pages/shared/assessment-field-keterangan";
 
 export const FormFieldRenderer = React.memo(function FormFieldRenderer({
   field,
@@ -42,11 +44,23 @@ export const FormFieldRenderer = React.memo(function FormFieldRenderer({
     setValue(fieldName, value.value || "");
   }, [value, field, fieldName, setValue]);
 
+  const scoreWeight =
+    field.metadata && typeof field.metadata.score_weight !== "undefined"
+      ? Number(field.metadata.score_weight)
+      : null;
+
+  const rangeKeterangan = resolveAssessmentKeterangan(
+    field.description,
+    field.competency_levels,
+    value?.value,
+  );
+
   const renderField = () => {
     switch (field.type) {
       case "checkbox":
         return (
-          <div className="mt-2">
+          <div className="mt-2 space-y-2">
+            <AssessmentFieldKeterangan description={field.description} />
             {Array.isArray(field.options) &&
               field.options.map((option: string) => (
                 <CheckboxForm
@@ -61,44 +75,63 @@ export const FormFieldRenderer = React.memo(function FormFieldRenderer({
 
       case "textarea":
         return (
-          <TextAreaForm
-            data-state="disabled"
-            name={fieldName}
-            label={field.label}
-            disabled
-            inputClassName="bg-grayscale-20 text-text-disabled"
-          />
+          <div className="mt-2 space-y-2">
+            <AssessmentFieldKeterangan description={field.description} />
+            <TextAreaForm
+              data-state="disabled"
+              name={fieldName}
+              disabled
+              inputClassName="bg-grayscale-20 text-text-disabled"
+            />
+          </div>
         );
 
       case "range":
         return (
-          <div className="flex gap-2">
-            {field.options && !Array.isArray(field.options) && (
-              <RadioCard
-                disabled
-                max={field.options.max}
-                min={field.options.min}
-                value={value?.value}
-              />
-            )}
+          <div className="mt-2 space-y-2">
+            <AssessmentFieldKeterangan
+              description={rangeKeterangan.description}
+              levelName={rangeKeterangan.levelName}
+            />
+            <div className="flex gap-2">
+              {field.options && !Array.isArray(field.options) && (
+                <RadioCard
+                  disabled
+                  max={field.options.max}
+                  min={field.options.min}
+                  value={value?.value}
+                />
+              )}
+            </div>
           </div>
         );
 
       default:
         return (
-          <InputForm
-            name={fieldName}
-            className="mt-2"
-            disabled
-            value={value?.value}
-          />
+          <div className="mt-2 space-y-2">
+            <AssessmentFieldKeterangan description={field.description} />
+            <InputForm
+              name={fieldName}
+              className="mt-2"
+              disabled
+              value={value?.value}
+            />
+          </div>
         );
     }
   };
 
   return (
     <div className="rounded-sm border border-grayscale-20 p-4 gap-4 w-full">
-      <span className="font-medium">{field.label}</span>
+      <span className="font-medium">
+        {field.label}
+        {scoreWeight != null && !Number.isNaN(scoreWeight) ? (
+          <span className="text-text-secondary font-normal">
+            {" "}
+            ({scoreWeight}%)
+          </span>
+        ) : null}
+      </span>
       {renderField()}
     </div>
   );

--- a/src/components/pages/performance-supervisor-assessment-details/sections/form-field-renderer.tsx
+++ b/src/components/pages/performance-supervisor-assessment-details/sections/form-field-renderer.tsx
@@ -7,6 +7,8 @@ import RadioCard from "@/components/ui/radio-card";
 import { FormField } from "@/components/pages/settings-form-template-details/type";
 import { IAssessmentField } from "@/services/employees/self-assessment/types";
 import { useFormContext } from "react-hook-form";
+import { resolveAssessmentKeterangan } from "@/lib/assessment-field-keterangan";
+import { AssessmentFieldKeterangan } from "@/components/pages/shared/assessment-field-keterangan";
 
 export const FormFieldRenderer = React.memo(function FormFieldRenderer({
   field,
@@ -43,11 +45,23 @@ export const FormFieldRenderer = React.memo(function FormFieldRenderer({
     }
   }, [value, field, setValue]);
 
+  const fieldName = value?.field_id?.toString() || field.id.toString();
+  const scoreWeight =
+    field.metadata && typeof field.metadata.score_weight !== "undefined"
+      ? Number(field.metadata.score_weight)
+      : null;
+  const rangeKeterangan = resolveAssessmentKeterangan(
+    field.description,
+    field.competency_levels,
+    value?.value,
+  );
+
   const renderField = () => {
     switch (field.type) {
       case "checkbox":
         return (
-          <div className="mt-2">
+          <div className="mt-2 space-y-2">
+            <AssessmentFieldKeterangan description={field.description} />
             {Array.isArray(field.options) &&
               field.options.map((option: string) => (
                 <CheckboxForm
@@ -62,44 +76,63 @@ export const FormFieldRenderer = React.memo(function FormFieldRenderer({
 
       case "textarea":
         return (
-          <TextAreaForm
-            data-state="disabled"
-            name={value?.field_id.toString() || field.id.toString()}
-            label={field.label}
-            disabled
-            inputClassName="bg-grayscale-20 text-text-disabled"
-          />
+          <div className="mt-2 space-y-2">
+            <AssessmentFieldKeterangan description={field.description} />
+            <TextAreaForm
+              data-state="disabled"
+              name={fieldName}
+              disabled
+              inputClassName="bg-grayscale-20 text-text-disabled"
+            />
+          </div>
         );
 
       case "range":
         return (
-          <div className="flex gap-2">
-            {field.options && !Array.isArray(field.options) && (
-              <RadioCard
-                disabled
-                max={field.options.max}
-                min={field.options.min}
-                value={value?.value}
-              />
-            )}
+          <div className="mt-2 space-y-2">
+            <AssessmentFieldKeterangan
+              description={rangeKeterangan.description}
+              levelName={rangeKeterangan.levelName}
+            />
+            <div className="flex gap-2">
+              {field.options && !Array.isArray(field.options) && (
+                <RadioCard
+                  disabled
+                  max={field.options.max}
+                  min={field.options.min}
+                  value={value?.value}
+                />
+              )}
+            </div>
           </div>
         );
 
       default:
         return (
-          <InputForm
-            name={value?.field_id.toString() || field.id.toString()}
-            className="mt-2"
-            disabled
-            value={value?.value}
-          />
+          <div className="mt-2 space-y-2">
+            <AssessmentFieldKeterangan description={field.description} />
+            <InputForm
+              name={fieldName}
+              className="mt-2"
+              disabled
+              value={value?.value}
+            />
+          </div>
         );
     }
   };
 
   return (
     <div className="rounded-sm border border-grayscale-20 p-4 gap-4 w-full">
-      <span className="font-medium">{field.label}</span>
+      <span className="font-medium">
+        {field.label}
+        {scoreWeight != null && !Number.isNaN(scoreWeight) ? (
+          <span className="text-text-secondary font-normal">
+            {" "}
+            ({scoreWeight}%)
+          </span>
+        ) : null}
+      </span>
       {renderField()}
     </div>
   );

--- a/src/components/pages/performance-supervisor-assessment-details/sections/performance-assessment.tsx
+++ b/src/components/pages/performance-supervisor-assessment-details/sections/performance-assessment.tsx
@@ -17,6 +17,8 @@ import { FormFieldRenderer } from "./form-field-renderer";
 import { Form } from "@/components/ui/form";
 import { useForm } from "react-hook-form";
 import { IFinalSubmission } from "@/services/performances/supervisor-assessment/types";
+import { resolveAssessmentKeterangan } from "@/lib/assessment-field-keterangan";
+import { AssessmentFieldKeterangan } from "@/components/pages/shared/assessment-field-keterangan";
 
 const CategoryDetails: React.FC<{
   group: IFormGroup;
@@ -40,35 +42,44 @@ const CategoryDetails: React.FC<{
       <CollapsibleContent className="space-y-4">
         {group.fields.map((item) => {
           if (item.type === "range") {
+            const submissionField = finalSubmission?.data?.fields?.find(
+              (f: any) => f.field_id === item.id,
+            );
+            const keterangan = resolveAssessmentKeterangan(
+              item.description,
+              item.competency_levels,
+              submissionField?.value != null
+                ? String(submissionField.value)
+                : null,
+            );
+
             return (
               <div
                 key={item.id}
-                className="border border-gray-200 rounded-lg p-4 flex flex-row justify-between"
+                className="border border-gray-200 rounded-lg p-4 flex flex-row justify-between gap-4"
               >
-                <div className="mb-2">
+                <div className="mb-2 flex-1 min-w-0">
                   <h4 className="font-semibold text-gray-900 text-sm">
                     {item.label} ({item.metadata?.score_weight || 0}%)
                   </h4>
-                  <p className="text-xs text-gray-600 mt-1">
-                    {item.description}
-                  </p>
+                  <AssessmentFieldKeterangan
+                    className="mt-1"
+                    description={keterangan.description}
+                    levelName={keterangan.levelName}
+                  />
                 </div>
-                <div className="flex items-center justify-end gap-6 pt-3">
+                <div className="flex items-center justify-end gap-6 pt-3 shrink-0">
                   <div className="text-right">
                     <p className="text-xs text-gray-500">Score</p>
                     <p className="text-sm font-semibold text-primary">
-                      {finalSubmission?.data?.fields?.find(
-                        (f: any) => f.field_id === item.id,
-                      )?.score_label || 0}
+                      {submissionField?.score_label || 0}
                     </p>
                   </div>
                   <Separator orientation="vertical" className="h-full" />
                   <div className="text-right">
                     <p className="text-xs text-gray-500">Sub Total</p>
                     <p className="text-sm font-semibold text-primary">
-                      {finalSubmission?.data?.fields?.find(
-                        (f: any) => f.field_id === item.id,
-                      )?.subtotal_score_label || 0}
+                      {submissionField?.subtotal_score_label || 0}
                     </p>
                   </div>
                 </div>

--- a/src/components/pages/settings-form-template-details/type.ts
+++ b/src/components/pages/settings-form-template-details/type.ts
@@ -5,6 +5,17 @@ export interface FormField {
   label: string;
   type: string;
   form_id: number;
+  description?: string | null;
+  metadata?: Record<string, unknown> | null;
+  competency_levels?:
+    | {
+        id: number;
+        dimensions: string;
+        level: string;
+        name: string;
+        description: string;
+      }[]
+    | null;
   options?:
     | string[]
     | {

--- a/src/components/pages/shared/assessment-field-keterangan.tsx
+++ b/src/components/pages/shared/assessment-field-keterangan.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface AssessmentFieldKeteranganProps {
+  description?: string | null;
+  levelName?: string | null;
+  className?: string;
+}
+
+/**
+ * Shows competency level name (tag helper) + keterangan under assessment items.
+ */
+export function AssessmentFieldKeterangan({
+  description,
+  levelName,
+  className,
+}: AssessmentFieldKeteranganProps) {
+  const trimmedDescription = description?.trim() || "";
+  const trimmedLevelName = levelName?.trim() || "";
+
+  if (!trimmedDescription && !trimmedLevelName) {
+    return null;
+  }
+
+  return (
+    <div className={cn("space-y-1.5", className)}>
+      {trimmedLevelName ? (
+        <span className="inline-flex items-center rounded-md border border-primary/20 bg-primary-background px-2 py-0.5 text-xs font-medium text-primary">
+          {trimmedLevelName}
+        </span>
+      ) : null}
+      {trimmedDescription ? (
+        <p className="text-sm text-text-secondary whitespace-pre-line">
+          {trimmedDescription}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/ui/radio-card.tsx
+++ b/src/components/ui/radio-card.tsx
@@ -39,7 +39,7 @@ const RadioCard = ({ disabled, min = 1, max = 5, value }: Props) => {
 
   return (
     <RadioGroupPrimitive.Root
-      className="w-full grid grid-cols-5 gap-3"
+      className="w-full flex flex-wrap gap-3"
       value={value}
     >
       {options.map((option) => (
@@ -48,7 +48,7 @@ const RadioCard = ({ disabled, min = 1, max = 5, value }: Props) => {
           value={option.value}
           disabled={disabled}
           className={cn(
-            "ring-[1px] ring-border rounded py-1 px-3 data-[state=checked]:ring-grayscale-20 data-[state=checked]:bg-grayscale-20",
+            "min-w-11 ring-[1px] ring-border rounded py-1 px-3 data-[state=checked]:ring-grayscale-20 data-[state=checked]:bg-grayscale-20",
           )}
         >
           <span className="text-text-disabled data-[state=checked]:text-white">

--- a/src/lib/assessment-field-keterangan.ts
+++ b/src/lib/assessment-field-keterangan.ts
@@ -1,0 +1,52 @@
+export type AssessmentCompetencyLevel = {
+  id?: number;
+  dimensions?: string;
+  level: string | number;
+  name?: string | null;
+  description?: string | null;
+};
+
+export type AssessmentKeteranganResult = {
+  description: string;
+  levelName: string | null;
+};
+
+/**
+ * Resolves display keterangan for assessment fields.
+ * When a score is selected and competency_levels exist, prefer that level's
+ * description/name (same behavior as mobile CompetencyRatingField).
+ */
+export function resolveAssessmentKeterangan(
+  description: string | null | undefined,
+  competencyLevels: AssessmentCompetencyLevel[] | null | undefined,
+  selectedRating?: string | number | null,
+): AssessmentKeteranganResult {
+  const baseDescription = description?.trim() || "";
+  let levelName: string | null = null;
+  let resolvedDescription = baseDescription;
+
+  if (
+    selectedRating !== undefined &&
+    selectedRating !== null &&
+    selectedRating !== "" &&
+    competencyLevels?.length
+  ) {
+    const matched = competencyLevels.find(
+      (level) => String(level.level) === String(selectedRating),
+    );
+
+    if (matched) {
+      const matchedName = matched.name?.trim();
+      if (matchedName) {
+        levelName = matchedName;
+      }
+
+      const matchedDescription = matched.description?.trim();
+      if (matchedDescription) {
+        resolvedDescription = matchedDescription;
+      }
+    }
+  }
+
+  return { description: resolvedDescription, levelName };
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -265,6 +265,11 @@
     "createNewPasswordSubtitle": "Create a new password for this account",
     "resetLinkInvalid": "This reset link is invalid or has expired. Please request a new one.",
     "requestNewResetLink": "Request a new reset link",
+    "openEssAppTitle": "Continue in ESS App",
+    "openEssAppSubtitle": "This password reset was requested from the mobile ESS app. Open the app to set your new password.",
+    "openEssAppCta": "Open ESS App",
+    "continueResetOnWeb": "Continue on web instead",
+    "openEssAppHint": "If the app does not open, install ESS CPS and tap Open ESS App again.",
     "newPasswordConfirmation": "New Password Confirmation",
     "logout": "Logout"
   },

--- a/src/messages/id.json
+++ b/src/messages/id.json
@@ -265,6 +265,11 @@
     "createNewPasswordSubtitle": "Buat kata sandi baru untuk akun ini",
     "resetLinkInvalid": "Tautan atur ulang tidak valid atau sudah kedaluwarsa. Silakan minta tautan baru.",
     "requestNewResetLink": "Minta tautan atur ulang baru",
+    "openEssAppTitle": "Lanjutkan di Aplikasi ESS",
+    "openEssAppSubtitle": "Permintaan atur ulang kata sandi ini dimulai dari aplikasi ESS. Buka aplikasi untuk mengatur kata sandi baru.",
+    "openEssAppCta": "Buka Aplikasi ESS",
+    "continueResetOnWeb": "Lanjutkan di web",
+    "openEssAppHint": "Jika aplikasi tidak terbuka, pasang ESS CPS lalu ketuk Buka Aplikasi ESS lagi.",
     "newPasswordConfirmation": "Konfirmasi Kata Sandi Baru",
     "logout": "Keluar"
   },

--- a/src/services/auth/types.ts
+++ b/src/services/auth/types.ts
@@ -21,6 +21,8 @@ export interface ILoginRequest {
 
 export interface IResetRequest { 
   email: string;
+  /** web → web reset page; mobile → ESS app via HTTPS bridge */
+  client?: 'web' | 'mobile';
 }
 
 export interface IResetResponse { 

--- a/src/services/form/types.ts
+++ b/src/services/form/types.ts
@@ -23,6 +23,7 @@ export interface IFormGroup {
   fields: {
     id: number;
     form_id: number;
+    field_group_id?: number;
     label: string;
     type: string;
     options: any[];

--- a/src/services/okr/types.ts
+++ b/src/services/okr/types.ts
@@ -131,9 +131,9 @@ export interface IOKRKeyResultRequest {
   format: number;
   start_value?: number;
   current_value?: number;
-  target_value: number;
+  target_value?: number;
   status?: number;
-  direction: number;
+  direction?: number;
   aggregation: number;
 }
 


### PR DESCRIPTION
## Summary
- Coerce empty/invalid KPI and OKR key-result target/direction to safe numeric defaults before API calls.
- Send `client: web` on forgot-password requests.
- Add `/app/reset-password` HTTPS bridge page that opens ESS via deep link, with a clear continue-on-web fallback.
- Also includes assessment keterangan/level helper UI fixes already on this branch.

## Test plan
- [ ] Create KPI with blank Target → request sends `0`, succeeds
- [ ] Add OKR key result with blank Target/Direction → succeeds
- [ ] Web forgot password → email opens `/reset-password` form
- [ ] Open `/app/reset-password?token=…&email=…` → tries ESS deep link and shows Open ESS / Continue on web
- [ ] ID/EN copy for bridge page renders correctly
