### PR TITLE
fix: add server pagination to settings list pages

### DIFF
--- a/src/app/docs/en/_meta.ts
+++ b/src/app/docs/en/_meta.ts
@@ -2,5 +2,6 @@ export default {
   "index": "Introduction",
   "manual": "User Manual",
   "workflows": "Workflows",
-  "faq": "FAQ"
+  "faq": "FAQ",
+  "changelog": "Changelog",
 }

--- a/src/app/docs/en/changelog/2026-07-31-whats-new/page.mdx
+++ b/src/app/docs/en/changelog/2026-07-31-whats-new/page.mdx
@@ -1,0 +1,16 @@
+# What’s New is here
+
+**31 July 2026**
+
+You can now follow product updates in plain language — for web and the mobile app.
+
+## What’s included
+
+- **Changelog in Docs** — Open [Changelog](/docs/changelog) anytime to see release notes written for everyday use (not technical notes).
+- **In-app notifications** — When we publish an update, everyone gets a notification. On web, tap it to open that release. On the mobile app, open **Inbox** to read the full text.
+- **Web and mobile covered** — Each note can mention changes that apply to the website, the app, or both.
+
+## Tips
+
+- Prefer the docs Changelog if you want the full history.
+- On mobile, use Inbox for the latest update details; the full timeline stays on the web docs.

--- a/src/app/docs/en/changelog/_meta.ts
+++ b/src/app/docs/en/changelog/_meta.ts
@@ -1,0 +1,4 @@
+export default {
+  index: 'Overview',
+  '2026-07-31-whats-new': 'What’s New is here',
+}

--- a/src/app/docs/en/changelog/page.mdx
+++ b/src/app/docs/en/changelog/page.mdx
@@ -1,0 +1,9 @@
+# Changelog
+
+Product updates written for everyday use — new features, improvements, and fixes that affect how you work in OkeJobHub HRMS (web and mobile).
+
+Entries appear here after each release. Open an entry for the full details. You may also receive an in-app notification when something new is published.
+
+## Releases
+
+- **[31 July 2026 — What’s New is here](/docs/changelog/2026-07-31-whats-new)** — Follow product updates in plain language on web and mobile.

--- a/src/app/docs/en/page.mdx
+++ b/src/app/docs/en/page.mdx
@@ -4,10 +4,11 @@ Welcome to the OkeJobHub HRMS documentation. This site helps you learn and use t
 
 ## How to use this documentation
 
-- **Sidebar** — Use the left sidebar to move between sections: **User Manual**, **Workflows**, and **FAQ**. Expand a section to see its pages.
+- **Sidebar** — Use the left sidebar to move between sections: **User Manual**, **Workflows**, **FAQ**, and **Changelog**. Expand a section to see its pages.
 - **User Manual** — Start with [User Manual](/docs/manual) for an overview, then use **Start Here** and **Core Concepts** to learn basics. The **Page Reference** lists every screen with a short description and a screenshot; use it to find a specific page quickly.
 - **Workflows** — Use [Workflows](/docs/workflows) for step-by-step guides (e.g. log in, request leave, process payrun). Each workflow has prerequisites, steps with links to the relevant pages, and common mistakes.
 - **FAQ** — Use [FAQ](/docs/faq) for short answers by topic (Login, Dashboard, Employee, Attendance, Payroll, Performance, Settings, ESS). Many answers link to a page or a workflow for more detail.
+- **Changelog** — Use [Changelog](/docs/changelog) for product updates in plain language (web and mobile). Entries appear after each release; you may also get an in-app notification.
 - **Search** — Use the search bar at the top to find topics or page names across the docs.
 
 If you don’t see a menu or feature in the app, it may be restricted by your role; ask your administrator.

--- a/src/app/docs/id/_meta.ts
+++ b/src/app/docs/id/_meta.ts
@@ -2,5 +2,6 @@ export default {
   "index": "Pengenalan",
   "manual": "Panduan Pengguna",
   "workflows": "Alur Kerja",
-  "faq": "Tanya Jawab"
+  "faq": "Tanya Jawab",
+  "changelog": "Catatan Perubahan",
 }

--- a/src/app/docs/id/changelog/2026-07-31-whats-new/page.mdx
+++ b/src/app/docs/id/changelog/2026-07-31-whats-new/page.mdx
@@ -1,0 +1,16 @@
+# Fitur What’s New sudah tersedia
+
+**31 Juli 2026**
+
+Kini Anda dapat mengikuti pembaruan produk dalam bahasa yang mudah dipahami — untuk web dan aplikasi seluler.
+
+## Apa yang termasuk
+
+- **Catatan Perubahan di Docs** — Buka [Catatan Perubahan](/docs/changelog) kapan saja untuk melihat catatan rilis yang ditulis untuk penggunaan sehari-hari (bukan catatan teknis).
+- **Notifikasi di aplikasi** — Saat kami menerbitkan pembaruan, semua orang menerima notifikasi. Di web, ketuk untuk membuka rilis tersebut. Di aplikasi seluler, buka **Kotak Masuk** untuk membaca teks lengkapnya.
+- **Web dan aplikasi tercakup** — Setiap catatan dapat menyebutkan perubahan yang berlaku di situs web, aplikasi, atau keduanya.
+
+## Tips
+
+- Gunakan Catatan Perubahan di docs jika Anda ingin melihat seluruh riwayat.
+- Di aplikasi seluler, gunakan Kotak Masuk untuk detail pembaruan terbaru; riwayat lengkap tetap tersedia di docs web.

--- a/src/app/docs/id/changelog/_meta.ts
+++ b/src/app/docs/id/changelog/_meta.ts
@@ -1,0 +1,4 @@
+export default {
+  index: 'Ikhtisar',
+  '2026-07-31-whats-new': 'Fitur What’s New sudah tersedia',
+}

--- a/src/app/docs/id/changelog/page.mdx
+++ b/src/app/docs/id/changelog/page.mdx
@@ -1,0 +1,9 @@
+# Catatan Perubahan
+
+Pembaruan produk dalam bahasa yang mudah dipahami — fitur baru, perbaikan, dan perubahan yang memengaruhi cara Anda bekerja di OkeJobHub HRMS (web dan aplikasi seluler).
+
+Entri muncul di sini setelah setiap rilis. Buka entri untuk detail lengkap. Anda juga dapat menerima notifikasi di aplikasi saat ada pembaruan baru.
+
+## Rilis
+
+- **[31 Juli 2026 — Fitur What’s New sudah tersedia](/docs/changelog/2026-07-31-whats-new)** — Ikuti pembaruan produk dalam bahasa yang mudah dipahami di web dan aplikasi seluler.

--- a/src/app/docs/id/page.mdx
+++ b/src/app/docs/id/page.mdx
@@ -4,10 +4,11 @@ Selamat datang di dokumentasi OkeJobHub HRMS. Situs ini membantu Anda mempelajar
 
 ## Cara menggunakan dokumentasi ini
 
-- **Sidebar** — Gunakan sidebar kiri untuk berpindah antar bagian: **Panduan Pengguna**, **Alur Kerja**, dan **Tanya Jawab**. Buka suatu bagian untuk melihat halamannya.
+- **Sidebar** — Gunakan sidebar kiri untuk berpindah antar bagian: **Panduan Pengguna**, **Alur Kerja**, **Tanya Jawab**, dan **Catatan Perubahan**. Buka suatu bagian untuk melihat halamannya.
 - **Panduan Pengguna** — Mulai dengan [Panduan Pengguna](/docs/manual) untuk gambaran umum, lalu gunakan **Mulai di Sini** dan **Konsep Dasar** untuk mempelajari dasar-dasarnya. **Referensi Halaman** memuat setiap layar dengan deskripsi singkat dan tangkapan layar; gunakan untuk menemukan halaman tertentu dengan cepat.
 - **Alur Kerja** — Gunakan [Alur Kerja](/docs/workflows) untuk panduan langkah demi langkah (mis. masuk, ajukan cuti, proses payrun). Setiap alur kerja memiliki prasyarat, langkah dengan tautan ke halaman terkait, dan kesalahan umum.
 - **Tanya Jawab** — Gunakan [Tanya Jawab](/docs/faq) untuk jawaban singkat per topik (Login, Dasbor, Karyawan, Kehadiran, Payroll, Kinerja, Pengaturan, ESS). Banyak jawaban menautkan ke halaman atau alur kerja untuk detail lebih lanjut.
+- **Catatan Perubahan** — Gunakan [Catatan Perubahan](/docs/changelog) untuk pembaruan produk dalam bahasa yang mudah dipahami (web dan aplikasi seluler). Entri muncul setelah setiap rilis; Anda juga dapat menerima notifikasi di aplikasi.
 - **Pencarian** — Gunakan bilah pencarian di atas untuk mencari topik atau nama halaman di seluruh dokumentasi.
 
 Jika Anda tidak melihat menu atau fitur di aplikasi, mungkin dibatasi oleh peran Anda; tanyakan kepada administrator.

--- a/src/components/pages/employee-management-form/sections/employee-information-section.tsx
+++ b/src/components/pages/employee-management-form/sections/employee-information-section.tsx
@@ -632,7 +632,7 @@ export const EmployeeinformationSection = React.memo(
       error: branchError,
     } = useQuery({
       queryKey: ["branch_id"],
-      queryFn: getBranches,
+      queryFn: () => getBranches(),
       retry: (failureCount, error: any) => {
         if (error?.response?.status >= 400) return false;
         return failureCount < 3;

--- a/src/components/pages/employee-management-form/sections/personal-information-section.tsx
+++ b/src/components/pages/employee-management-form/sections/personal-information-section.tsx
@@ -29,7 +29,7 @@ export const PersonalInformationSection = React.memo(
     const tCommon = useTranslations("common");
     const { data: roles } = useQuery({
       queryKey: ["roles"],
-      queryFn: getRoles,
+      queryFn: () => getRoles(),
     });
 
     const { watch, setValue, getValues, formState } = useFormContext();

--- a/src/components/pages/employee-management-list/sections/advanced-filters.tsx
+++ b/src/components/pages/employee-management-list/sections/advanced-filters.tsx
@@ -143,6 +143,7 @@ export const AdvancedFilter = React.memo(function AdvancedFilter({
                 maxCount={1}
                 variant="inverted"
                 name="job_position_ids"
+                valueTransformer={(value) => Number(value)}
               />
             </div>
 
@@ -154,6 +155,7 @@ export const AdvancedFilter = React.memo(function AdvancedFilter({
                 placeholder={t("allDepartment")}
                 name="department_ids"
                 searchPlaceholder={t("searchDepartment")}
+                valueTransformer={(value) => Number(value)}
               />
             </div>
             <div>

--- a/src/components/pages/employee-management-list/sections/toolbar.tsx
+++ b/src/components/pages/employee-management-list/sections/toolbar.tsx
@@ -44,6 +44,10 @@ export const Toolbar = React.memo(function Toolbar({
     control: form.control,
     name: "job_position_ids",
   });
+  const search = useWatch({
+    control: form.control,
+    name: "search",
+  });
 
   const { data: departments } = useQuery({
     queryKey: ["departments"],
@@ -119,7 +123,7 @@ export const Toolbar = React.memo(function Toolbar({
         clearTimeout(debouncedSubmit.current);
       }
     };
-  }, [departmentIds, jobPositionIds, form, onSubmit]);
+  }, [departmentIds, jobPositionIds, search, form, onSubmit]);
 
   const handleAdvancedFilters = (filters: Filters) => {
     console.log("Advanced filters applied:", filters);
@@ -170,6 +174,7 @@ export const Toolbar = React.memo(function Toolbar({
               maxCount={1}
               searchPlaceholder={t("searchPosition")}
               allSelectLabel={t("allPosition")}
+              valueTransformer={(value) => Number(value)}
             />
           </div>
 
@@ -182,6 +187,7 @@ export const Toolbar = React.memo(function Toolbar({
               maxCount={1}
               searchPlaceholder={t("searchDepartment")}
               allSelectLabel={t("allDepartment")}
+              valueTransformer={(value) => Number(value)}
             />
           </div>
           <Button

--- a/src/components/pages/offboarding/index.tsx
+++ b/src/components/pages/offboarding/index.tsx
@@ -170,7 +170,6 @@ export default function EmployeeOffboardingList({
       ...debouncedFilters,
       page: pagination.pageIndex + 1,
       per_page: pagination.pageSize,
-      search: '',
     }),
     [debouncedFilters, pagination],
   );

--- a/src/components/pages/offboarding/sections/advanced-filters.tsx
+++ b/src/components/pages/offboarding/sections/advanced-filters.tsx
@@ -25,8 +25,8 @@ export const AdvancedFilter = React.memo(function AdvancedFilter({
   const t = useTranslations("employee");
   const tCommon = useTranslations("common");
   const initValues: Filters = {
-    department_id: 0,
-    job_position_id: 0,
+    department_id: undefined,
+    job_position_id: undefined,
     search: "",
     start_date: null,
     end_date: null,
@@ -76,13 +76,24 @@ export const AdvancedFilter = React.memo(function AdvancedFilter({
     return [];
   }, [positions?.data]);
 
+  const toSingleId = (value: unknown): number => {
+    if (Array.isArray(value)) {
+      const first = value[0];
+      const parsed = Number(first);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  };
+
   const onSubmit = (values: Filters) => {
     try {
-      console.log("onSubmit ", values);
+      const departmentId = toSingleId(values.department_id);
+      const jobPositionId = toSingleId(values.job_position_id);
       const normalized: Filters = {
         ...values,
-        department_id: values.department_id,
-        job_position_id: values.job_position_id,
+        department_id: departmentId || undefined,
+        job_position_id: jobPositionId || undefined,
         start_date: values.start_date
           ? dayjs(values.start_date as unknown as Date).format("YYYY-MM-DD")
           : null,
@@ -141,6 +152,7 @@ export const AdvancedFilter = React.memo(function AdvancedFilter({
                 maxCount={1}
                 variant="inverted"
                 name="job_position_id"
+                valueTransformer={(value) => Number(value)}
               />
             </div>
 
@@ -152,6 +164,7 @@ export const AdvancedFilter = React.memo(function AdvancedFilter({
                 placeholder={t("allDepartment")}
                 name="department_id"
                 searchPlaceholder={t("searchDepartment")}
+                valueTransformer={(value) => Number(value)}
               />
             </div>
             <div>

--- a/src/components/pages/offboarding/sections/initiate-offboarding-form.tsx
+++ b/src/components/pages/offboarding/sections/initiate-offboarding-form.tsx
@@ -29,7 +29,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { Plus } from "lucide-react";
 import * as React from "react";
-import { useForm } from "react-hook-form";
+import { Resolver, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import { Can } from "@/components/auth/can";
@@ -49,7 +49,9 @@ export const InitiateOffboardingEmployee = React.memo(
     const queryClient = useQueryClient();
 
     const form = useForm<IMutateOffboardingRequests>({
-      resolver: zodResolver(MutateOffboardingRequestsSchema),
+      resolver: zodResolver(
+        MutateOffboardingRequestsSchema,
+      ) as unknown as Resolver<IMutateOffboardingRequests>,
       defaultValues: {
         user_id: 0,
         approvers: [],

--- a/src/components/pages/offboarding/sections/initiate-offboarding-form.tsx
+++ b/src/components/pages/offboarding/sections/initiate-offboarding-form.tsx
@@ -26,12 +26,17 @@ import {
 import { getAllForm } from "@/services/form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import dayjs from "dayjs";
 import { Plus } from "lucide-react";
 import * as React from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import { Can } from "@/components/auth/can";
+import { HTTPError } from "ky";
+
+/** Must match Form::TYPE_EXIT_INTERVIEW on the backend. */
+const EXIT_INTERVIEW_FORM_TYPE = 1;
 
 export const InitiateOffboardingEmployee = React.memo(
   function InitiateOffboardingEmployee() {
@@ -44,7 +49,7 @@ export const InitiateOffboardingEmployee = React.memo(
     const queryClient = useQueryClient();
 
     const form = useForm<IMutateOffboardingRequests>({
-      // resolver: zodResolver(MutateOffboardingRequestsSchema),
+      resolver: zodResolver(MutateOffboardingRequestsSchema),
       defaultValues: {
         user_id: 0,
         approvers: [],
@@ -68,8 +73,8 @@ export const InitiateOffboardingEmployee = React.memo(
     });
 
     const { data: forms } = useQuery({
-      queryKey: ["forms"],
-      queryFn: () => getAllForm(),
+      queryKey: ["forms", "exit-interview"],
+      queryFn: () => getAllForm({ type: EXIT_INTERVIEW_FORM_TYPE }),
       staleTime: 5 * 60 * 1000,
       gcTime: 10 * 60 * 1000,
       refetchOnWindowFocus: false,
@@ -106,19 +111,45 @@ export const InitiateOffboardingEmployee = React.memo(
         form.reset();
         setIsOpen(false);
       },
-      onError: (error: any) => {
+      onError: async (error: unknown) => {
         console.error("Mutation error:", error);
-        toast.error(t("initiateFailed"));
+        if (error instanceof HTTPError) {
+          try {
+            const errorData = (await error.response.json()) as {
+              message?: string;
+              errors?: Record<string, string[]>;
+            };
+            const firstFieldError = errorData.errors
+              ? Object.values(errorData.errors).flat()[0]
+              : undefined;
+            toast.error(
+              firstFieldError || errorData.message || t("initiateFailed"),
+            );
+            return;
+          } catch {
+            // fall through
+          }
+        }
+        toast.error(
+          error instanceof Error && error.message
+            ? `${t("initiateFailed")}: ${error.message}`
+            : t("initiateFailed"),
+        );
       },
     });
 
     const onSubmit = React.useCallback(
       (values: IMutateOffboardingRequests) => {
-        console.log("on submit offboarding", values);
         mutation.mutate({
-          ...values,
           user_id: Number(values.user_id),
           form_id: Number(values.form_id),
+          approvers: values.approvers.map(Number),
+          effective_resignation_date: dayjs(
+            values.effective_resignation_date,
+          ).format("YYYY-MM-DD"),
+          last_working_date: dayjs(values.last_working_date).format(
+            "YYYY-MM-DD",
+          ),
         });
       },
       [mutation],

--- a/src/components/pages/offboarding/sections/toolbar.tsx
+++ b/src/components/pages/offboarding/sections/toolbar.tsx
@@ -26,8 +26,8 @@ export const Toolbar = React.memo(function Toolbar({
   const t = useTranslations("employee");
   const tCommon = useTranslations("common");
   const initValues = {
-    department_id: 0,
-    job_position_id: 0,
+    department_id: undefined,
+    job_position_id: undefined,
     search: "",
   };
   const [isAdvanced, setIsAdvanced] = React.useState(false);
@@ -43,6 +43,10 @@ export const Toolbar = React.memo(function Toolbar({
   const jobPositionIds = useWatch({
     control: form.control,
     name: "job_position_id",
+  });
+  const search = useWatch({
+    control: form.control,
+    name: "search",
   });
 
   const { data: departments } = useQuery({
@@ -89,16 +93,27 @@ export const Toolbar = React.memo(function Toolbar({
 
   const debouncedSubmit = React.useRef<NodeJS.Timeout | null>(null);
 
+  const toSingleId = React.useCallback((value: unknown): number => {
+    if (Array.isArray(value)) {
+      const first = value[0];
+      const parsed = Number(first);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  }, []);
+
   const onSubmit = React.useCallback(
     (values: Filters) => {
-      console.log("Basic filter submit:", values);
+      const departmentId = toSingleId(values.department_id);
+      const jobPositionId = toSingleId(values.job_position_id);
       onFiltersChange({
         ...values,
-        department_id: values.department_id,
-        job_position_id: values.job_position_id,
+        department_id: departmentId || undefined,
+        job_position_id: jobPositionId || undefined,
       });
     },
-    [onFiltersChange],
+    [onFiltersChange, toSingleId],
   );
 
   React.useEffect(() => {
@@ -117,7 +132,7 @@ export const Toolbar = React.memo(function Toolbar({
         clearTimeout(debouncedSubmit.current);
       }
     };
-  }, [departmentIds, jobPositionIds, form, onSubmit]);
+  }, [departmentIds, jobPositionIds, search, form, onSubmit]);
 
   const handleAdvancedFilters = (filters: Filters) => {
     console.log("Advanced filters applied:", filters);
@@ -168,6 +183,7 @@ export const Toolbar = React.memo(function Toolbar({
               maxCount={1}
               searchPlaceholder={t("searchPosition")}
               allSelectLabel={t("allPosition")}
+              valueTransformer={(value) => Number(value)}
             />
           </div>
 
@@ -180,6 +196,7 @@ export const Toolbar = React.memo(function Toolbar({
               maxCount={1}
               searchPlaceholder={t("searchDepartment")}
               allSelectLabel={t("allDepartment")}
+              valueTransformer={(value) => Number(value)}
             />
           </div>
           <Button

--- a/src/components/pages/settings-access-control-list/hook.ts
+++ b/src/components/pages/settings-access-control-list/hook.ts
@@ -1,32 +1,50 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { getRoles } from "@/services/settings";
 import { IRole } from "@/services/settings/types";
+import { useQuery } from "@tanstack/react-query";
+import { PaginationState } from "@tanstack/react-table";
+import { ApiPagination } from "@/lib/types";
+import { useState } from "react";
 
 export function useRoleManagement() {
-  const [roles, setRoles] = useState<IRole[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
   const router = useRouter();
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
 
-  const fetchRoles = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
+  const {
+    data: rolesResponse,
+    isLoading: loading,
+    error,
+    refetch: fetchRoles,
+  } = useQuery({
+    queryKey: ["roles", pagination.pageIndex, pagination.pageSize],
+    queryFn: () =>
+      getRoles({
+        page: pagination.pageIndex + 1,
+        per_page: pagination.pageSize,
+      }),
+    placeholderData: (previousData) => previousData,
+  });
 
-      const res = await getRoles();
-      setRoles(res.data ?? []);
-    } catch (err: unknown) {
-      console.error("Failed to fetch roles:", err);
-      setError(err instanceof Error ? err.message : "Unexpected error");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
+  const roles: IRole[] = rolesResponse?.data ?? [];
+  const apiPagination: ApiPagination | undefined = rolesResponse
+    ? {
+        current_page: rolesResponse.current_page,
+        per_page: rolesResponse.per_page,
+        total: rolesResponse.total,
+        last_page: rolesResponse.last_page,
+        from: rolesResponse.from ?? 0,
+        to: rolesResponse.to ?? 0,
+        first: rolesResponse.first_page_url,
+        last: "",
+        prev: rolesResponse.prev_page_url,
+        next: rolesResponse.next_page_url,
+      }
+    : undefined;
 
   const handleNew = () => {
     router.push("/settings/access-control/add");
@@ -36,14 +54,17 @@ export function useRoleManagement() {
     router.push(`/settings/access-control/${id}`);
   };
 
-  useEffect(() => {
-    fetchRoles();
-  }, [fetchRoles]);
-
   return {
     roles,
+    apiPagination,
+    pagination,
+    setPagination,
     loading,
-    error,
+    error: error
+      ? error instanceof Error
+        ? error.message
+        : "Unexpected error"
+      : null,
     fetchRoles,
     handleNew,
     handleEdit,

--- a/src/components/pages/settings-access-control-list/index.tsx
+++ b/src/components/pages/settings-access-control-list/index.tsx
@@ -15,7 +15,8 @@ import { Can } from '@/components/auth/can';
 export default function SettingsAccessControl() {
   const t = useTranslations('settings');
   const tCommon = useTranslations('common');
-  const { roles, handleEdit, handleNew } = useRoleManagement();
+  const { roles, apiPagination, pagination, setPagination, loading, handleEdit, handleNew } =
+    useRoleManagement();
 
   const columns: ColumnDef<IRole>[] = [
     {
@@ -100,7 +101,15 @@ export default function SettingsAccessControl() {
               </Button>
             </Can>
           </div>
-          <DataTable columns={columns} data={roles} customSize={!isMobile} />
+          <DataTable
+            columns={columns}
+            data={roles}
+            customSize={!isMobile}
+            apiPagination={apiPagination}
+            paginationState={pagination}
+            setPaginationState={setPagination}
+            loading={loading}
+          />
         </div>
       </div>
     </div>

--- a/src/components/pages/settings-company-branch-list/hook.ts
+++ b/src/components/pages/settings-company-branch-list/hook.ts
@@ -4,25 +4,34 @@ import { useRouter } from "next/navigation";
 import { deleteBranch, getBranches } from "@/services/settings";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { PaginationState } from "@tanstack/react-table";
+import { ApiPagination } from "@/lib/types";
 
 export function useCompanyBranchList() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const [isDeleteModal, setIsDeleteModal] = React.useState(false);
   const [idBranch, setIdBranch] = React.useState("");
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
+
   const {
-    data: branchesData,
+    data: branchesResponse,
     isLoading: loading,
     error,
     refetch: fetchBranches,
     isError,
     isSuccess,
   } = useQuery({
-    queryKey: ["company-branches"],
-    queryFn: async () => {
-      const response = await getBranches();
-      return response.data ?? [];
-    },
+    queryKey: ["company-branches", pagination.pageIndex, pagination.pageSize],
+    queryFn: () =>
+      getBranches({
+        page: pagination.pageIndex + 1,
+        per_page: pagination.pageSize,
+      }),
+    placeholderData: (previousData) => previousData,
   });
 
   const mutateDeleteBranch = useMutation({
@@ -38,7 +47,9 @@ export function useCompanyBranchList() {
     },
   });
 
-  const branches = branchesData ?? [];
+  const branches = branchesResponse?.data ?? [];
+  const apiPagination: ApiPagination | undefined =
+    branchesResponse?.pagination;
 
   const handleNew = () => {
     router.push("/settings/company/company-branch/add");
@@ -59,6 +70,9 @@ export function useCompanyBranchList() {
 
   return {
     branches,
+    apiPagination,
+    pagination,
+    setPagination,
     loading,
     error: error
       ? error instanceof Error

--- a/src/components/pages/settings-company-branch-list/index.tsx
+++ b/src/components/pages/settings-company-branch-list/index.tsx
@@ -28,6 +28,10 @@ export default function SettingsCompanyBranchList() {
   const locale = resolveLocale(useLocale());
   const {
     branches,
+    apiPagination,
+    pagination,
+    setPagination,
+    loading,
     handleEdit,
     handleNew,
     handleDeleteBranch,
@@ -176,7 +180,15 @@ export default function SettingsCompanyBranchList() {
               </Button>
             </Can>
           </div>
-          <DataTable columns={columns} data={branches} customSize={!isMobile} />
+          <DataTable
+            columns={columns}
+            data={branches}
+            customSize={!isMobile}
+            apiPagination={apiPagination}
+            paginationState={pagination}
+            setPaginationState={setPagination}
+            loading={loading}
+          />
         </div>
       </div>
       <DeleteDialog

--- a/src/components/pages/settings-salary-management/allowance/index.tsx
+++ b/src/components/pages/settings-salary-management/allowance/index.tsx
@@ -4,8 +4,8 @@ import * as React from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { DataTable } from '@/components/tables/data-table';
-import { ColumnDef } from '@tanstack/react-table';
-import { Plus, Trash2, CalendarIcon } from 'lucide-react';
+import { ColumnDef, PaginationState } from '@tanstack/react-table';
+import { Plus, Trash2 } from 'lucide-react';
 import { RowActions } from '@/components/tables/row-actions';
 import { Can } from '@/components/auth/can';
 import dayjs from 'dayjs';
@@ -71,14 +71,26 @@ export default function SettingsBaseAllowance() {
   const [openDetail, setOpenDetail] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
   const [editing, setEditing] = React.useState<AllowanceItem | null>(null);
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
   const queryClient = useQueryClient();
 
-  const { data: allowanceData, refetch: allowanceDataRefetch } =
-    useQuery<ResponseAllowance>({
-      queryKey: ['getAllowance'],
-      queryFn: getAllowance,
-      staleTime: 1000 * 60 * 5,
-    });
+  const {
+    data: allowanceData,
+    refetch: allowanceDataRefetch,
+    isLoading: isAllowanceLoading,
+  } = useQuery<ResponseAllowance>({
+    queryKey: ['getAllowance', pagination.pageIndex, pagination.pageSize],
+    queryFn: () =>
+      getAllowance({
+        page: pagination.pageIndex + 1,
+        per_page: pagination.pageSize,
+      }),
+    staleTime: 1000 * 60 * 5,
+    placeholderData: (previousData) => previousData,
+  });
 
   const { data: jobLevel } = useQuery<PaginatedResponse<JobLevel>>({
     queryKey: ['jobLevel'],
@@ -286,7 +298,14 @@ export default function SettingsBaseAllowance() {
         </Can>
       </div>
 
-      <DataTable columns={columns} data={allowanceData?.data} />
+      <DataTable
+        columns={columns}
+        data={allowanceData?.data}
+        apiPagination={allowanceData?.pagination}
+        paginationState={pagination}
+        setPaginationState={setPagination}
+        loading={isAllowanceLoading}
+      />
 
       {/* Modal Form */}
       <Dialog open={open} onOpenChange={setOpen}>

--- a/src/components/pages/settings-salary-management/base-salary/index.tsx
+++ b/src/components/pages/settings-salary-management/base-salary/index.tsx
@@ -4,8 +4,8 @@ import * as React from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { DataTable } from '@/components/tables/data-table';
-import { ColumnDef } from '@tanstack/react-table';
-import { Plus, CalendarIcon } from 'lucide-react';
+import { ColumnDef, PaginationState } from '@tanstack/react-table';
+import { Plus } from 'lucide-react';
 import { RowActions } from '@/components/tables/row-actions';
 import { Can } from '@/components/auth/can';
 import dayjs from 'dayjs';
@@ -72,14 +72,30 @@ export default function SettingsBaseSalary() {
   const [openDetail, setOpenDetail] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
   const [editing, setEditing] = React.useState<BaseSalaryItem | null>(null);
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
   const queryClient = useQueryClient();
 
-  const { data: baseSalaryData, refetch: baseSalaryDataRefetch } =
-    useQuery<ResponseBaseSalary>({
-      queryKey: ['getBaseSalary'],
-      queryFn: () => getBaseSalary(),
-      staleTime: 1000 * 60 * 5,
-    });
+  const {
+    data: baseSalaryData,
+    refetch: baseSalaryDataRefetch,
+    isLoading: isBaseSalaryLoading,
+  } = useQuery<ResponseBaseSalary>({
+    queryKey: [
+      'getBaseSalary',
+      pagination.pageIndex,
+      pagination.pageSize,
+    ],
+    queryFn: () =>
+      getBaseSalary({
+        page: pagination.pageIndex + 1,
+        per_page: pagination.pageSize,
+      }),
+    staleTime: 1000 * 60 * 5,
+    placeholderData: (previousData) => previousData,
+  });
 
   const { data: jobLevel } = useQuery<PaginatedResponse<JobLevel>>({
     queryKey: ['jobLevel'],
@@ -288,7 +304,14 @@ export default function SettingsBaseSalary() {
         </Can>
       </div>
 
-      <DataTable columns={columns} data={baseSalaryData?.data} />
+      <DataTable
+        columns={columns}
+        data={baseSalaryData?.data}
+        apiPagination={baseSalaryData?.pagination}
+        paginationState={pagination}
+        setPaginationState={setPagination}
+        loading={isBaseSalaryLoading}
+      />
 
       {/* Modal Form */}
       <Dialog open={open} onOpenChange={setOpen}>

--- a/src/components/pages/settings-salary-management/deduction/index.tsx
+++ b/src/components/pages/settings-salary-management/deduction/index.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { DataTable } from '@/components/tables/data-table';
-import { ColumnDef } from '@tanstack/react-table';
+import { ColumnDef, PaginationState } from '@tanstack/react-table';
 import { Plus, Trash2 } from 'lucide-react';
 import { RowActions } from '@/components/tables/row-actions';
 import { Can } from '@/components/auth/can';
@@ -43,7 +43,7 @@ import {
 } from '@/services/salary';
 import { Textarea } from '@/components/ui/textarea';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { ApiResponse, PaginatedResponse } from '@/lib/types';
+import { ApiPagination, ApiResponse, PaginatedResponse } from '@/lib/types';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -64,13 +64,52 @@ export default function SettingsSalaryDeduction() {
   const [editing, setEditing] = React.useState<DeductionSalaryItem | null>(
     null,
   );
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
   const queryClient = useQueryClient();
 
-  const { data: deductionData, refetch: deductionDataRefetch } = useQuery({
-    queryKey: ['getDeductionSalary'],
-    queryFn: getDeductionSalary,
+  const {
+    data: deductionData,
+    refetch: deductionDataRefetch,
+    isLoading: isDeductionLoading,
+  } = useQuery({
+    queryKey: [
+      'getDeductionSalary',
+      pagination.pageIndex,
+      pagination.pageSize,
+    ],
+    queryFn: () =>
+      getDeductionSalary({
+        page: pagination.pageIndex + 1,
+        per_page: pagination.pageSize,
+      }),
     staleTime: 1000 * 60 * 5,
+    placeholderData: (previousData) => previousData,
   });
+
+  const deductionApiPagination: ApiPagination | undefined = deductionData?.data
+    ? {
+        current_page: deductionData.data.current_page,
+        per_page: deductionData.data.per_page,
+        total: deductionData.data.total,
+        last_page:
+          deductionData.data.last_page ??
+          Math.max(
+            1,
+            Math.ceil(
+              deductionData.data.total / Math.max(1, deductionData.data.per_page),
+            ),
+          ),
+        from: deductionData.data.from ?? 0,
+        to: deductionData.data.to ?? 0,
+        first: deductionData.data.first_page_url,
+        last: '',
+        prev: deductionData.data.prev_page_url,
+        next: deductionData.data.next_page_url,
+      }
+    : undefined;
 
   const { data: deductionDataType } = useQuery({
     queryKey: ['getDeductionSalaryType'],
@@ -312,7 +351,14 @@ export default function SettingsSalaryDeduction() {
         </Can>
       </div>
 
-      <DataTable columns={columns} data={deductionData?.data.data} />
+      <DataTable
+        columns={columns}
+        data={deductionData?.data.data}
+        apiPagination={deductionApiPagination}
+        paginationState={pagination}
+        setPaginationState={setPagination}
+        loading={isDeductionLoading}
+      />
 
       {/* Modal Form */}
       <Dialog open={open} onOpenChange={setOpen}>

--- a/src/components/pages/settings-score/index.tsx
+++ b/src/components/pages/settings-score/index.tsx
@@ -19,7 +19,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { PaginatedResponse } from '@/lib/types';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -53,21 +52,6 @@ export default function SettingsScore() {
     queryFn: () => getScore(pagination),
     staleTime: 1000 * 60 * 5,
   });
-
-  const dataPagination: PaginatedResponse<ScoreList> = {
-    current_page: score?.pagination.current_page ?? 1,
-    current_page_url: `${score?.pagination.first ?? ''}`,
-    first_page_url: score?.pagination.first ?? '',
-    from: score?.pagination.from ?? 0,
-    last_page: score?.pagination.last_page ?? 1,
-    next_page_url: score?.pagination.next ?? null,
-    path: 'api/v1/setting/score-thresholds',
-    per_page: score?.pagination.per_page ?? 10,
-    prev_page_url: score?.pagination.prev ?? null,
-    to: score?.pagination.to ?? 0,
-    total: score?.pagination.total ?? 0,
-    data: score?.data ?? [],
-  };
 
   const columns: ColumnDef<ScoreList>[] = [
     {
@@ -212,7 +196,7 @@ export default function SettingsScore() {
       <DataTable
         columns={columns}
         data={score?.data}
-        pagination={dataPagination}
+        apiPagination={score?.pagination}
         paginationState={pagination}
         setPaginationState={setPagination}
       />

--- a/src/components/pages/settings-time-list/hook.ts
+++ b/src/components/pages/settings-time-list/hook.ts
@@ -18,9 +18,10 @@ import {
   WorkScheduleReq,
   WorkScheduleResponse,
 } from "@/services/settings/types";
-import { PaginatedResponse } from "@/lib/types";
+import { ApiPagination, PaginatedResponse } from "@/lib/types";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
+import { PaginationState } from "@tanstack/react-table";
 
 // =======================
 // Types lokal untuk UI
@@ -144,16 +145,72 @@ export function useLateDeduction() {
   const [selectedData, setSelectedData] = useState<LateDeductions>();
   const [branches, setBranches] = useState<ICompanyBranches[]>([]);
   const [loading, setLoading] = useState(false);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
   const queryClient = useQueryClient();
 
   // list late deduction
-  const { data: lateDeductionData, refetch: lateDeductionRefetch } = useQuery<
-    PaginatedResponse<LateDeductions>
-  >({
-    queryKey: ["lateDeduction"],
-    queryFn: getLateDeduction,
+  const {
+    data: lateDeductionData,
+    refetch: lateDeductionRefetch,
+    isLoading: isLateDeductionLoading,
+  } = useQuery({
+    queryKey: ["lateDeduction", pagination.pageIndex, pagination.pageSize],
+    queryFn: () =>
+      getLateDeduction({
+        page: pagination.pageIndex + 1,
+        limit: pagination.pageSize,
+      }),
     staleTime: 1000 * 60 * 5,
+    placeholderData: (previousData) => previousData,
   });
+
+  // Supports Laravel paginator shape and API Resource collection ({ data, meta, links }).
+  const lateDeductionRows =
+    lateDeductionData?.data ??
+    (Array.isArray(lateDeductionData) ? lateDeductionData : []);
+  const lateMeta = (lateDeductionData as { meta?: Record<string, number> } | undefined)
+    ?.meta;
+  const lateLinks = (
+    lateDeductionData as { links?: Record<string, string | null> } | undefined
+  )?.links;
+  const apiPagination: ApiPagination | undefined = lateMeta
+    ? {
+        current_page: lateMeta.current_page,
+        per_page: lateMeta.per_page,
+        total: lateMeta.total,
+        last_page: lateMeta.last_page,
+        from: lateMeta.from ?? 0,
+        to: lateMeta.to ?? 0,
+        first: lateLinks?.first ?? "",
+        last: lateLinks?.last ?? "",
+        prev: lateLinks?.prev ?? null,
+        next: lateLinks?.next ?? null,
+      }
+    : lateDeductionData && "current_page" in lateDeductionData
+      ? {
+          current_page: lateDeductionData.current_page,
+          per_page: lateDeductionData.per_page,
+          total: lateDeductionData.total,
+          last_page:
+            lateDeductionData.last_page ??
+            Math.max(
+              1,
+              Math.ceil(
+                lateDeductionData.total /
+                  Math.max(1, lateDeductionData.per_page),
+              ),
+            ),
+          from: lateDeductionData.from ?? 0,
+          to: lateDeductionData.to ?? 0,
+          first: lateDeductionData.first_page_url,
+          last: "",
+          prev: lateDeductionData.prev_page_url,
+          next: lateDeductionData.next_page_url,
+        }
+      : undefined;
 
   const fetchBranches = useCallback(async () => {
     try {
@@ -263,6 +320,11 @@ export function useLateDeduction() {
 
   return {
     lateDeductionData,
+    lateDeductionRows,
+    apiPagination,
+    pagination,
+    setPagination,
+    isLateDeductionLoading,
     open,
     setOpen,
     openDelete,

--- a/src/components/pages/settings-time-list/index.tsx
+++ b/src/components/pages/settings-time-list/index.tsx
@@ -30,7 +30,11 @@ export default function SettingsAttendanceConfiguration() {
   const tCommon = useTranslations("common");
 
   const {
-    lateDeductionData,
+    lateDeductionRows,
+    apiPagination,
+    pagination,
+    setPagination,
+    isLateDeductionLoading,
     handleEdit,
     handleDeleteClick,
     handleAdd,
@@ -38,10 +42,12 @@ export default function SettingsAttendanceConfiguration() {
     setOpen,
     selectedData,
     handleCloseLateDeduction,
-    loadingSave,
+    handleSaveLateDeduction,
     openDelete,
     setOpenDelete,
     handleDeleteConfirm,
+    shiftOptions,
+    loadingSave,
     branches,
   } = useLateDeduction();
 
@@ -200,7 +206,11 @@ export default function SettingsAttendanceConfiguration() {
         </div>
         <DataTable
           columns={lateDeductionColumn}
-          data={lateDeductionData?.data || []}
+          data={lateDeductionRows}
+          apiPagination={apiPagination}
+          paginationState={pagination}
+          setPaginationState={setPagination}
+          loading={isLateDeductionLoading}
         />
       </div>
     );

--- a/src/components/partials/notification-list.tsx
+++ b/src/components/partials/notification-list.tsx
@@ -6,6 +6,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { formatDistanceToNow } from 'date-fns';
 import { LucideBell } from 'lucide-react';
+import { useLocale } from 'next-intl';
 
 import { api } from '@/lib/api';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -14,12 +15,22 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
 import { Separator } from '@/components/ui/separator';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { resolveLocale } from '@/lib/i18n/locale';
+
+interface WhatsNewPayload {
+  slug?: string;
+  docs_path?: string;
+  title_en?: string;
+  title_id?: string;
+  message_en?: string;
+  message_id?: string;
+}
 
 interface NotificationData {
   title: string;
   message: string;
   code: string;
-  data?: any;
+  data?: WhatsNewPayload & Record<string, unknown>;
 }
 
 interface NotificationItem {
@@ -29,6 +40,27 @@ interface NotificationItem {
   read_at: string | null;
   created_at: string;
   updated_at: string;
+}
+
+function getWhatsNewDisplay(
+  item: NotificationItem,
+  locale: string
+): { title: string; message: string } {
+  const payload = item.data.data;
+  const isEn = resolveLocale(locale) === 'en';
+
+  if (item.data.code !== 'WHATS_NEW' || !payload) {
+    return { title: item.data.title, message: item.data.message };
+  }
+
+  const title = isEn
+    ? payload.title_en || item.data.title
+    : payload.title_id || item.data.title;
+  const message = isEn
+    ? payload.message_en || item.data.message
+    : payload.message_id || item.data.message;
+
+  return { title, message };
 }
 
 interface NotificationResponse {
@@ -42,6 +74,7 @@ interface NotificationResponse {
 
 export function NotificationList() {
   const router = useRouter();
+  const locale = useLocale();
   const [open, setOpen] = React.useState(false);
 
   const {
@@ -130,6 +163,11 @@ export function NotificationList() {
       case 'OFFBOARDING_VALIDATE_HANDOVER':
         targetRoute = '/employee/off-boarding';
         break;
+      case 'WHATS_NEW':
+        targetRoute =
+          (typeof item.data.data?.docs_path === 'string' && item.data.data.docs_path) ||
+          '/docs/changelog';
+        break;
       default:
         break;
     }
@@ -183,7 +221,10 @@ export function NotificationList() {
         ) : (
           <ScrollArea className="h-[350px] overflow-y-auto">
             <div className="flex flex-col">
-              {notifications.map((notification, index) => (
+              {notifications.map((notification, index) => {
+                const display = getWhatsNewDisplay(notification, locale);
+
+                return (
                 <div
                   key={notification.id}
                   ref={index === notifications.length - 1 ? lastNotificationRef : null}
@@ -195,7 +236,7 @@ export function NotificationList() {
                 >
                   <div className="flex justify-between items-start gap-2">
                     <span className="font-semibold text-gray-800 line-clamp-1">
-                      {notification.data.title}
+                      {display.title}
                     </span>
                     <span className="text-[10px] text-gray-400 whitespace-nowrap min-w-max mt-0.5">
                       {formatDistanceToNow(new Date(notification.created_at), { addSuffix: true })}
@@ -205,16 +246,17 @@ export function NotificationList() {
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <p className="text-xs text-gray-600 line-clamp-2 leading-relaxed text-left cursor-default">
-                          {notification.data.message}
+                          {display.message}
                         </p>
                       </TooltipTrigger>
                       <TooltipContent className="max-w-[250px] z-[100] break-words">
-                        <p className="text-xs">{notification.data.message}</p>
+                        <p className="text-xs whitespace-pre-wrap">{display.message}</p>
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>
                 </div>
-              ))}
+                );
+              })}
               {isFetchingNextPage && (
                 <div className="p-4 text-center text-xs text-gray-400">
                   Loading more...

--- a/src/services/employees/offboardings/index.ts
+++ b/src/services/employees/offboardings/index.ts
@@ -61,10 +61,10 @@ export const getOffboardings = (
   return response.json();
 };
 
-export const createInitiateOffboarding = (
+export const createInitiateOffboarding = async (
   params: IMutateOffboardingRequests,
 ): Promise<ApiResponse<ICreateEmployeeResponse>> => {
-  const response = api.post<ApiResponse<ICreateEmployeeResponse>>(
+  const response = await api.post<ApiResponse<ICreateEmployeeResponse>>(
     `employee/offboardings`,
     {
       json: params,

--- a/src/services/employees/offboardings/types.ts
+++ b/src/services/employees/offboardings/types.ts
@@ -1,13 +1,23 @@
 import { z } from "zod";
+import dayjs from "dayjs";
+
+const requiredDate = (message: string) =>
+  z
+    .union([z.string(), z.date()])
+    .refine((v) => !!v && String(v).trim() !== "" && dayjs(v).isValid(), {
+      message,
+    });
 
 export const MutateOffboardingRequestsSchema = z.object({
-  user_id: z.number(),
-  effective_resignation_date: z
-    .string()
-    .min(1, "effective_resignation_date is required"),
-  last_working_date: z.string().min(1, "last_working_date is required"),
-  form_id: z.number(),
-  approvers: z.array(z.number()).nonempty("At least one approver is required"),
+  user_id: z.coerce.number().positive("Employee is required"),
+  effective_resignation_date: requiredDate(
+    "effective_resignation_date is required",
+  ),
+  last_working_date: requiredDate("last_working_date is required"),
+  form_id: z.coerce.number().positive("Exit interview form is required"),
+  approvers: z
+    .array(z.coerce.number())
+    .nonempty("At least one approver is required"),
 });
 
 export type IMutateOffboardingRequests = z.infer<

--- a/src/services/salary/index.ts
+++ b/src/services/salary/index.ts
@@ -15,13 +15,14 @@ import {
 import { ApiResponse, PaginatedResponse } from "@/lib/types";
 import qs from "qs";
 
-export const getAllowance = async (): Promise<ResponseAllowance> => {
-  const response = await api.get("allowance-types", {
-    searchParams: {
-      page: "1",
-      per_page: "10000",
-    },
-  });
+export const getAllowance = async (
+  search?: IParamSearch,
+): Promise<ResponseAllowance> => {
+  const response = await api.get(
+    search
+      ? `allowance-types?${qs.stringify(search)}`
+      : "allowance-types?page=1&per_page=10000",
+  );
   return response.json();
 };
 
@@ -103,10 +104,15 @@ export const removeBaseSalary = async (
     .json<ResponseBaseSalary>();
 };
 
-export const getDeductionSalary = async (): Promise<
-  ApiResponse<PaginatedResponse<DeductionSalaryItem>>
-> => {
-  const response = await api.get("setting/salary-deduction?per_page=20");
+export const getDeductionSalary = async (params?: {
+  page?: number | string;
+  per_page?: number | string;
+}): Promise<ApiResponse<PaginatedResponse<DeductionSalaryItem>>> => {
+  const searchParams: Record<string, string> = {
+    page: String(params?.page ?? 1),
+    per_page: String(params?.per_page ?? 10),
+  };
+  const response = await api.get("setting/salary-deduction", { searchParams });
   return response.json();
 };
 

--- a/src/services/salary/types.ts
+++ b/src/services/salary/types.ts
@@ -2,6 +2,18 @@ export interface ResponseAllowance {
   data: AllowanceItem[];
   message: string;
   status: string;
+  pagination?: {
+    current_page: number;
+    per_page: number;
+    total: number;
+    last_page: number;
+    from: number;
+    to: number;
+    first: string;
+    last: string;
+    prev: string | null;
+    next: string | null;
+  };
 }
 
 export interface AllowanceItem {
@@ -39,6 +51,18 @@ export interface ResponseBaseSalary {
   data: BaseSalaryItem[];
   message: string;
   status: string;
+  pagination?: {
+    current_page: number;
+    per_page: number;
+    total: number;
+    last_page: number;
+    from: number;
+    to: number;
+    first: string;
+    last: string;
+    prev: string | null;
+    next: string | null;
+  };
 }
 
 export interface BaseSalaryItem {
@@ -113,6 +137,9 @@ export interface IParamSearch {
   JobPosition?: string;
   job_level_id?: string;
   job_position_id?: string;
+  page?: string | number;
+  per_page?: string | number;
+  search?: string;
 }
 
 export interface DeductionSalaryItemTypeList {

--- a/src/services/settings/index.ts
+++ b/src/services/settings/index.ts
@@ -24,13 +24,16 @@ import {
   LeaveTypeRequest,
   LeaveConfigDetail,
 } from "./types";
-import { ApiResponse, PaginatedResponse } from "@/lib/types";
+import { ApiPagination, ApiResponse, PaginatedResponse } from "@/lib/types";
 
-export const getRoles = async (): Promise<IRolesResponse> => {
+export const getRoles = async (params?: {
+  page?: number | string;
+  per_page?: number | string;
+}): Promise<IRolesResponse> => {
   const response = await api.get("roles", {
     searchParams: {
-      page: "1",
-      per_page: "10000",
+      page: String(params?.page ?? 1),
+      per_page: String(params?.per_page ?? 10000),
     },
   });
   return response.json();
@@ -114,11 +117,16 @@ export const updateAttendanceTime = async (
     .json<WorkScheduleResponse>();
 };
 
-export const getLateDeduction = async (): Promise<
-  PaginatedResponse<LateDeductions>
-> => {
+export const getLateDeduction = async (params?: {
+  page?: number | string;
+  limit?: number | string;
+}): Promise<PaginatedResponse<LateDeductions>> => {
+  const searchParams: Record<string, string> = {
+    page: String(params?.page ?? 1),
+    limit: String(params?.limit ?? 10),
+  };
   return api
-    .get("setting/late-deduction")
+    .get("setting/late-deduction", { searchParams })
     .json<PaginatedResponse<LateDeductions>>();
 };
 
@@ -185,14 +193,31 @@ export const postOvertimeConfig = async (
     .json<OvertimeApiModel>();
 };
 
-export const getBranches = async (): Promise<
-  PaginatedResponse<ICompanyBranches>
+export const getBranches = async (params?: {
+  page?: number | string;
+  per_page?: number | string;
+}): Promise<
+  PaginatedResponse<ICompanyBranches> & {
+    pagination?: ApiPagination;
+    status?: string;
+    message?: string;
+  }
 > => {
   try {
-    // Align with getBranchesAll so branch SelectForms keep preselected IDs visible.
+    const searchParams: Record<string, string> = {
+      page: String(params?.page ?? 1),
+      // Keep a large default so dropdown callers (no args) still get full lists.
+      per_page: String(params?.per_page ?? 10000),
+    };
     return api
-      .get(`setting/branch?per_page=10000`)
-      .json<PaginatedResponse<ICompanyBranches>>();
+      .get(`setting/branch`, { searchParams })
+      .json<
+        PaginatedResponse<ICompanyBranches> & {
+          pagination?: ApiPagination;
+          status?: string;
+          message?: string;
+        }
+      >();
   } catch (error: any) {
     if (error.name === "HTTPError") {
       const errorResponse = await error.response.json();

--- a/src/services/settings/types.ts
+++ b/src/services/settings/types.ts
@@ -19,6 +19,8 @@ export interface IRolesResponse {
   per_page: number;
   prev_page_url: string | null;
   to: number;
+  total: number;
+  last_page: number;
 }
 
 export interface IRoleDetailResponse {


### PR DESCRIPTION
## Summary
- Wire server-side pagination into settings tables: base salary, allowance, deduction, assessment score, company branches, access-control roles, and late deduction
- Harden offboarding/employee list filters (normalize multi-select IDs, keep search in query params) and notification list handling
- Add bilingual docs changelog / What’s New section (EN + ID)

## Test plan
- [ ] `/settings/salary-management/base-salary` pager shows all pages (~61 rows)
- [ ] Allowance, deduction, score, company branch, access control, late deduction lists paginate
- [ ] Employee + offboarding filters still submit numeric department/position IDs
- [ ] Offboarding search is applied (not wiped) when paging
- [ ] Docs changelog pages render under EN/ID
