### PR TITLE
ci: bugbit v1.2.0 LGTM on clean PRs

### DIFF
--- a/.github/workflows/bugbit-pr-review.yml
+++ b/.github/workflows/bugbit-pr-review.yml
@@ -23,14 +23,17 @@ permissions:
 
 jobs:
   bugbit_review:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.sender.type != 'Bot' && github.event.pull_request.draft == false) }}
+    # Skip bots, drafts, and fork PRs (forks cannot access CURSOR_API_KEY secrets)
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch'
+          || (github.event.sender.type != 'Bot'
+              && github.event.pull_request.draft == false
+              && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - name: Resolve PR number
         id: pr
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -40,19 +43,21 @@ jobs:
           fi
 
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        # Pin to v4.2.2 (not mutable @v4)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
           ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          persist-credentials: false
 
       - name: Run bugbit review
-        # Pin to v1.1.1 commit (not mutable @v1) — receives CURSOR_API_KEY + PR write token
-        uses: Vilancer/bugbit@6ccf486a42256fe738d03b786bcdec9e1ff9015e
+        # JuicyBurger/bugbit v1.2.0 — LGTM on empty findings (post-clean-summary)
+        uses: JuicyBurger/bugbit@1973872dc10239c51b2480f3e0549668b8dc85fe
         with:
           cursor-api-key: ${{ secrets.CURSOR_API_KEY }}
           github-token: ${{ github.token }}
           # Cursor SDK Auto (server-selected). Avoids pinning Claude/GPT/etc.
-          # See: https://cursor.com/docs/sdk/typescript#model-ids-auto-smart-auto-and-default
           model: auto
           review-modes: code-review
+          post-clean-summary: true
           pr-number: ${{ steps.pr.outputs.number }}


### PR DESCRIPTION
## Summary
- Switch to [JuicyBurger/bugbit@v1.2.0](https://github.com/JuicyBurger/bugbit/releases/tag/v1.2.0)
- Clean PRs get a visible **LGTM / no findings** COMMENT review (`post-clean-summary: true`)
- Also applies fork-skip + pinned checkout + `persist-credentials: false`

## Test plan
- [ ] Merge
- [ ] Open a clean PR into `dev` or `staging` and confirm LGTM appears when there are no findings