### PR TITLE
Promote staging: numeric employment status on employee edit

### DIFF
--- a/src/components/pages/employee-management-form/add/index.tsx
+++ b/src/components/pages/employee-management-form/add/index.tsx
@@ -153,11 +153,13 @@ export const AddEmployeeForm = React.memo(function AddEmployee() {
         })),
         phone_number: Number(convertPhoneToNumber(String(values.phone_number))),
         bank_id: Number(values.bank_id),
-        npwp: values.npwp ?? null,
-        bpjs: values.bpjs ?? null,
-        hobby: values.hobby ?? null,
-        achievement: values.achievement ?? null,
-        personal_description: values.personal_description ?? null,
+        npwp: values.npwp?.trim() ? values.npwp : null,
+        bpjs: values.bpjs?.trim() ? values.bpjs : null,
+        hobby: values.hobby?.trim() ? values.hobby : null,
+        achievement: values.achievement?.trim() ? values.achievement : null,
+        personal_description: values.personal_description?.trim()
+          ? values.personal_description
+          : null,
         work_experiences: values.work_experiences?.filter((item) => item.id),
         contact_refferences: values.contact_refferences?.filter(
           (item) => item.id,
@@ -190,7 +192,7 @@ export const AddEmployeeForm = React.memo(function AddEmployee() {
 
       mutate(params);
     },
-    [mutate],
+    [form, mutate, tValidation],
   );
 
   const handleAddEmployee = React.useCallback(async () => {

--- a/src/components/pages/employee-management-form/add/index.tsx
+++ b/src/components/pages/employee-management-form/add/index.tsx
@@ -13,7 +13,7 @@ import { AttachmentsSection } from "../sections/attachments-section";
 import {
   createEmployeeManagementFormScheme,
   employeeManagementFormDefaultValues,
-  toEmploymentStatusValue,
+  toEmploymentStatusPayload,
   type EmployeeManagementFormValues,
 } from "../types";
 import { IMutateEmployeeRequests } from "@/services/employees/types";
@@ -119,18 +119,27 @@ export const AddEmployeeForm = React.memo(function AddEmployee() {
 
       const { end_date, countryCode, team_member, ...restValues } = values;
 
+      const employmentStatus = toEmploymentStatusPayload(values.status);
+      if (employmentStatus === undefined) {
+        form.setError("status", {
+          type: "manual",
+          message: tValidation("employmentStatusInvalid"),
+        });
+        return;
+      }
+
       const params: IMutateEmployeeRequests = {
         ...restValues,
         role_id: Number(values.role_id),
         department_id: Number(values.department_id),
         job_level_id: Number(values.job_level_id),
         job_position_id: Number(values.job_position_id),
-        status: toEmploymentStatusValue(values.status),
+        status: employmentStatus,
         marital_status: String(values.marital_status),
         ...(filteredSocialMedia && {
           social_media_accounts: filteredSocialMedia,
         }),
-        country_code: String(values.country_code),
+        country_code: String(values.country_code || "62").replace(/^\+/, ""),
         branch_id: Number(values.branch_id),
         team_id: Number(team_member),
         date_of_birth: dayjs(values.date_of_birth).format("YYYY-MM-DD"),
@@ -144,6 +153,11 @@ export const AddEmployeeForm = React.memo(function AddEmployee() {
         })),
         phone_number: Number(convertPhoneToNumber(String(values.phone_number))),
         bank_id: Number(values.bank_id),
+        npwp: values.npwp ?? null,
+        bpjs: values.bpjs ?? null,
+        hobby: values.hobby ?? null,
+        achievement: values.achievement ?? null,
+        personal_description: values.personal_description ?? null,
         work_experiences: values.work_experiences?.filter((item) => item.id),
         contact_refferences: values.contact_refferences?.filter(
           (item) => item.id,

--- a/src/components/pages/employee-management-form/edit/index.tsx
+++ b/src/components/pages/employee-management-form/edit/index.tsx
@@ -13,7 +13,9 @@ import { AttachmentsSection } from "../sections/attachments-section";
 import { Button } from "../../../ui/button";
 import {
   employeeManagementFormDefaultValues,
+  toEmploymentStatusPayload,
   toEmploymentStatusValue,
+  createEmployeeManagementFormScheme,
   type EmployeeManagementFormValues,
 } from "../types";
 import { IMutateEmployeeRequests } from "@/services/employees/types";
@@ -32,7 +34,7 @@ import AppSkeleton from "@/components/partials/app-skeleton";
 import { ApiErrorResponse } from "@/lib/types";
 import { COMPENSATION_VIEW_PERMISSION } from "@/lib/compensation";
 import { usePermissionStore } from "@/hooks/use-permission-store";
-
+import { useTranslations } from "next-intl";
 interface Props {
   employee_profile_id: number;
 }
@@ -43,8 +45,15 @@ export const EditEmployeeForm = React.memo(function EditEmployee({
   const router = useRouter();
   const [isDataLoaded, setIsDataLoaded] = React.useState(false);
   const queryClient = useQueryClient();
+  const t = useTranslations("employee");
+  const tValidation = useTranslations("validation");
   const canViewCompensation = usePermissionStore((state) =>
     state.can(COMPENSATION_VIEW_PERMISSION),
+  );
+
+  const employeeSchema = React.useMemo(
+    () => createEmployeeManagementFormScheme(tValidation, t),
+    [tValidation, t],
   );
 
   const { data, isLoading } = useQuery({
@@ -113,7 +122,7 @@ export const EditEmployeeForm = React.memo(function EditEmployee({
     });
 
   const form = useForm<EmployeeManagementFormValues>({
-    // resolver: zodResolver(createEmployeeManagementFormScheme(tValidation, t)),
+    resolver: zodResolver(employeeSchema),
     defaultValues: employeeManagementFormDefaultValues,
     mode: "onChange",
   });
@@ -167,6 +176,8 @@ export const EditEmployeeForm = React.memo(function EditEmployee({
         name: employeeDetails.user?.name || "",
         email: employeeDetails.user?.email || "",
         phone_number: employeeDetails.phone_number?.toString() || "",
+        country_code:
+          employeeDetails.country_code?.toString().replace(/^\+/, "") || "62",
         date_of_birth: employeeDetails.date_of_birth
           ? new Date(employeeDetails.date_of_birth)
           : new Date(),
@@ -297,6 +308,15 @@ export const EditEmployeeForm = React.memo(function EditEmployee({
             }
           : {};
 
+        const employmentStatus = toEmploymentStatusPayload(values.status);
+        if (employmentStatus === undefined) {
+          form.setError("status", {
+            type: "manual",
+            message: "Select a valid status (Active or Inactive)",
+          });
+          return;
+        }
+
         const baseParams: IMutateEmployeeRequests = {
           ...restValues,
           ...salaryParams,
@@ -306,13 +326,18 @@ export const EditEmployeeForm = React.memo(function EditEmployee({
           job_position_id: Number(values.job_position_id) || 0,
           phone_number: Number(values.phone_number) || 0,
           bank_id: Number(values.bank_id) || 0,
-          status: toEmploymentStatusValue(values.status),
+          status: employmentStatus,
           marital_status: String(values.marital_status),
           date_of_birth: dayjs(values.date_of_birth).format("YYYY-MM-DD"),
           start_date: dayjs(values.start_date).format("YYYY-MM-DD"),
           attachments: attachments || [],
           branch_id: Number(values.branch_id),
-          country_code: values.country_code || "",
+          country_code: String(values.country_code || "62").replace(/^\+/, ""),
+          npwp: values.npwp ?? null,
+          bpjs: values.bpjs ?? null,
+          hobby: values.hobby ?? null,
+          achievement: values.achievement ?? null,
+          personal_description: values.personal_description ?? null,
         };
 
         const conditionalParams: Partial<IMutateEmployeeRequests> = {
@@ -404,6 +429,7 @@ export const EditEmployeeForm = React.memo(function EditEmployee({
       canViewCompensation,
       editEmployee,
       filterValidData,
+      form,
       hasValidSocialMediaAccounts,
     ],
   );

--- a/src/components/pages/employee-management-form/edit/index.tsx
+++ b/src/components/pages/employee-management-form/edit/index.tsx
@@ -326,11 +326,13 @@ export const EditEmployeeForm = React.memo(function EditEmployee({
           attachments: attachments || [],
           branch_id: Number(values.branch_id),
           country_code: String(values.country_code || "62").replace(/^\+/, ""),
-          npwp: values.npwp ?? null,
-          bpjs: values.bpjs ?? null,
-          hobby: values.hobby ?? null,
-          achievement: values.achievement ?? null,
-          personal_description: values.personal_description ?? null,
+          npwp: values.npwp?.trim() ? values.npwp : null,
+          bpjs: values.bpjs?.trim() ? values.bpjs : null,
+          hobby: values.hobby?.trim() ? values.hobby : null,
+          achievement: values.achievement?.trim() ? values.achievement : null,
+          personal_description: values.personal_description?.trim()
+            ? values.personal_description
+            : null,
         };
 
         const conditionalParams: Partial<IMutateEmployeeRequests> = {

--- a/src/components/pages/employee-management-form/edit/index.tsx
+++ b/src/components/pages/employee-management-form/edit/index.tsx
@@ -4,7 +4,6 @@
 import { Form } from "@/components/ui/form";
 import * as React from "react";
 import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
 import { EmployeeinformationSection } from "../sections/employee-information-section";
 import { PersonalInformationSection } from "../sections/personal-information-section";
 import { SalaryInformationSection } from "../sections/salary-information-section";
@@ -15,7 +14,6 @@ import {
   employeeManagementFormDefaultValues,
   toEmploymentStatusPayload,
   toEmploymentStatusValue,
-  createEmployeeManagementFormScheme,
   type EmployeeManagementFormValues,
 } from "../types";
 import { IMutateEmployeeRequests } from "@/services/employees/types";
@@ -45,15 +43,9 @@ export const EditEmployeeForm = React.memo(function EditEmployee({
   const router = useRouter();
   const [isDataLoaded, setIsDataLoaded] = React.useState(false);
   const queryClient = useQueryClient();
-  const t = useTranslations("employee");
   const tValidation = useTranslations("validation");
   const canViewCompensation = usePermissionStore((state) =>
     state.can(COMPENSATION_VIEW_PERMISSION),
-  );
-
-  const employeeSchema = React.useMemo(
-    () => createEmployeeManagementFormScheme(tValidation, t),
-    [tValidation, t],
   );
 
   const { data, isLoading } = useQuery({
@@ -121,8 +113,9 @@ export const EditEmployeeForm = React.memo(function EditEmployee({
       },
     });
 
+  // Keep resolver off on edit: when compensation.view is hidden, base_salary is
+  // intentionally unset/masked and would fail the shared create schema.
   const form = useForm<EmployeeManagementFormValues>({
-    resolver: zodResolver(employeeSchema),
     defaultValues: employeeManagementFormDefaultValues,
     mode: "onChange",
   });
@@ -312,7 +305,7 @@ export const EditEmployeeForm = React.memo(function EditEmployee({
         if (employmentStatus === undefined) {
           form.setError("status", {
             type: "manual",
-            message: "Select a valid status (Active or Inactive)",
+            message: tValidation("employmentStatusInvalid"),
           });
           return;
         }
@@ -431,6 +424,7 @@ export const EditEmployeeForm = React.memo(function EditEmployee({
       filterValidData,
       form,
       hasValidSocialMediaAccounts,
+      tValidation,
     ],
   );
 

--- a/src/components/pages/employee-management-form/sections/employee-information-section.tsx
+++ b/src/components/pages/employee-management-form/sections/employee-information-section.tsx
@@ -887,6 +887,7 @@ export const EmployeeinformationSection = React.memo(
               { label: tCommon("inactive"), value: "2" },
             ]}
             required
+            allowClear={false}
           />
           <Separator className="md:col-span-2 my-4" />
         </div>

--- a/src/components/pages/employee-management-form/types.ts
+++ b/src/components/pages/employee-management-form/types.ts
@@ -11,10 +11,29 @@ export function toEmploymentStatusValue(
   if (status === null || status === undefined || status === "") {
     return "";
   }
-  const normalized = String(status);
-  if (normalized === "1") return "1";
-  if (normalized === "2" || normalized === "0") return "2";
+  const normalized = String(status).trim().toLowerCase();
+  if (normalized === "1" || normalized === "active" || normalized === "aktif") {
+    return "1";
+  }
+  if (
+    normalized === "2" ||
+    normalized === "0" ||
+    normalized === "inactive" ||
+    normalized === "tidak aktif"
+  ) {
+    return "2";
+  }
   return "";
+}
+
+/** API expects numeric employment status (1|2). */
+export function toEmploymentStatusPayload(
+  status: string | number | null | undefined,
+): 1 | 2 | undefined {
+  const value = toEmploymentStatusValue(status);
+  if (value === "1") return 1;
+  if (value === "2") return 2;
+  return undefined;
 }
 
 const attachmentLabelKeys: Record<string, string> = {

--- a/src/components/ui/select-form.tsx
+++ b/src/components/ui/select-form.tsx
@@ -42,6 +42,7 @@ const SelectForm: React.FC<OptionFormProps> = ({
   disabled,
   searchValue,
   onSearchChange,
+  allowClear,
 }) => {
   const tCommon = useTranslations("common");
 
@@ -61,6 +62,7 @@ const SelectForm: React.FC<OptionFormProps> = ({
       disabled={disabled}
       searchValue={searchValue}
       onSearchChange={onSearchChange}
+      allowClear={allowClear}
     />
   );
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -128,6 +128,7 @@ export interface OptionFormProps extends InputFormProps {
   type?: "string" | "number";
   searchValue?: string;
   onSearchChange?: (value: string) => void;
+  allowClear?: boolean;
 }
 
 export type BasicDatePickerProps = DayPickerProps & {

--- a/src/services/employees/types.ts
+++ b/src/services/employees/types.ts
@@ -94,7 +94,7 @@ export interface IMutateEmployeeRequests {
   team_id?: number;
   start_date: string;
   end_date?: string;
-  status: string;
+  status: string | number;
   /** Omitted when the editor lacks compensation.view (BE preserves existing). */
   base_salary?: number | null;
   salary_nett?: number;
@@ -131,6 +131,7 @@ export interface IMutateEmployeeRequests {
 export interface IEmployeeDetailsResponse {
   id: number;
   user_id: number;
+  country_code?: string | number | null;
   phone_number: string;
   gender: string;
   date_of_birth: string;


### PR DESCRIPTION
## Summary
Promote staging to main with the employee status hotfix:
- Submit employment status as numeric `1|2` (map labels / legacy `0`)
- Harden edit/create submit for optional nullable fields
- Keep edit zod resolver off when compensation fields are masked

Pairs with core-hrms employee update optional-field hardening.

## Test plan
- [ ] Edit employee → set Status to Inactive → save succeeds
- [ ] Confirm request payload `status` is `2`